### PR TITLE
Force disconnect when error received or connection canceled

### DIFF
--- a/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
@@ -30,7 +30,7 @@ extension WebSocketEngine: WebSocketDelegate {
 
         switch state {
         case .connecting:
-            connection.disconnect()
+            connection.forceDisconnect()
 
             let attempt = reconnectionAttempts[selectedURL] ?? 0
             scheduleReconnectionOrDisconnect(attempt + 1)
@@ -39,7 +39,7 @@ extension WebSocketEngine: WebSocketDelegate {
 
             pingScheduler.cancel()
 
-            connection.disconnect()
+            connection.forceDisconnect()
             scheduleReconnectionOrDisconnect(1)
 
             notify(
@@ -72,7 +72,7 @@ extension WebSocketEngine: WebSocketDelegate {
                 error: JSONRPCEngineError.clientCancelled
             )
         case .connecting:
-            connection.disconnect()
+            connection.forceDisconnect()
 
             let attempt = reconnectionAttempts[selectedURL] ?? 0
             scheduleReconnectionOrDisconnect(attempt + 1)


### PR DESCRIPTION
Currently, there is a problem that on graceful disconnect app connection send close code via web sockets and waits the response. Due to the bug in the library streams are not properly released with connection and when the response is received  the app may crash because streams try to use connection object. Current solution solves the problem by forcing disconnect that prevents sending any close code to the node.