### PR TITLE
Communicate selected URL for connected state of Websocket

### DIFF
--- a/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
@@ -104,7 +104,7 @@ extension WebSocketEngine: WebSocketDelegate {
         logger?.debug("(\(chainName):\(selectedURL)) connection established")
 
         updateReconnectionAttempts(0, for: selectedURL)
-        changeState(.connected)
+        changeState(.connected(url: selectedURL))
         sendAllPendingRequests()
 
         schedulePingIfNeeded()

--- a/SubstrateSdk/Classes/Network/WebSocketEngine.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine.swift
@@ -24,11 +24,11 @@ public protocol WebSocketEngineDelegate: AnyObject {
 }
 
 public final class WebSocketEngine {
-    public enum State {
+    public enum State: Equatable {
         case notConnected
         case connecting
         case waitingReconnection
-        case connected
+        case connected(url: URL)
     }
 
     public private(set) var urls: [URL]


### PR DESCRIPTION
Pass the selected URL for the connection in the `.connected` state of `WebSocketEngine` so the delegate can use it.