### PR TITLE
Fix/derive color for evm address icon

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -40,7 +40,7 @@ PODS:
   - secp256k1.c (0.1.3)
   - sr25519.c (0.1.0)
   - Starscream (4.0.4)
-  - SubstrateSdk (3.7.0):
+  - SubstrateSdk (3.7.2):
     - BigInt (~> 5.0)
     - keccak.c (~> 0.1.0)
     - NovaCrypto/ed25519 (~> 0.1.0)
@@ -138,7 +138,7 @@ SPEC CHECKSUMS:
   secp256k1.c: 9df12a79da0a6735022c5d996d2df6a6e57e1d99
   sr25519.c: 6c5d747682f45fd081c1e34d54cd322acee321b5
   Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
-  SubstrateSdk: c434ebab9612d4d2b3ce9d55800eca04a04cfea4
+  SubstrateSdk: c7205ad049a346226fff1e4df462c017d2380d72
   SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
   TweetNacl: 3abf4d1d2082b0114e7a67410e300892448951e6
   xxHash-Swift: 30bd6a7507b3b7348a277c49b1cb6346c2905ec7

--- a/SubstrateSdk.podspec
+++ b/SubstrateSdk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SubstrateSdk'
-  s.version          = '3.7.1'
+  s.version          = '3.7.2'
   s.summary          = 'Utility library that implements clients specific logic to interact with substrate based networks'
 
   s.homepage         = 'https://github.com/nova-wallet/substrate-sdk-ios'

--- a/SubstrateSdk/Classes/Icon/Nova/NovaIconGenerator.swift
+++ b/SubstrateSdk/Classes/Icon/Nova/NovaIconGenerator.swift
@@ -41,7 +41,10 @@ public final class NovaIconGenerator {
         let colors = Self.allColorPairs
 
         let accountId: [UInt8] = data.map { $0 }
-        let index = (UInt(accountId[30]) + UInt(accountId[31]) * 256) % UInt(colors.count)
+        
+        let lastByteIndex = accountId.endIndex - 1
+
+        let index = (UInt(accountId[lastByteIndex - 1]) + UInt(accountId[lastByteIndex]) * 256) % UInt(colors.count)
 
         return colors[Int(index)]
     }


### PR DESCRIPTION
## SUMMARY

This PR adds a safer approach to forming color indexes when deriving colors for accountId, preventing out-of-bounds crashes for 20-byte addresses.