### PR TITLE
Fix color derivation by index for NovaIconGenerator

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -40,7 +40,7 @@ PODS:
   - secp256k1.c (0.1.3)
   - sr25519.c (0.1.0)
   - Starscream (4.0.4)
-  - SubstrateSdk (3.7.0):
+  - SubstrateSdk (4.0.3):
     - BigInt (~> 5.0)
     - keccak.c (~> 0.1.0)
     - NovaCrypto/ed25519 (~> 0.1.0)
@@ -141,7 +141,7 @@ SPEC CHECKSUMS:
   secp256k1.c: 9df12a79da0a6735022c5d996d2df6a6e57e1d99
   sr25519.c: 6c5d747682f45fd081c1e34d54cd322acee321b5
   Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
-  SubstrateSdk: c434ebab9612d4d2b3ce9d55800eca04a04cfea4
+  SubstrateSdk: a2c04c7b06152e0fc8cc1f21f97835e94a5330a1
   SwiftFormat: 73573b89257437c550b03d934889725fbf8f75e5
   SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
   TweetNacl: 3abf4d1d2082b0114e7a67410e300892448951e6

--- a/SubstrateSdk.podspec
+++ b/SubstrateSdk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SubstrateSdk'
-  s.version          = '4.0.2'
+  s.version          = '4.0.3'
   s.summary          = 'Utility library that implements clients specific logic to interact with substrate based networks'
 
   s.homepage         = 'https://github.com/nova-wallet/substrate-sdk-ios'

--- a/SubstrateSdk/Classes/Icon/Nova/NovaIconGenerator.swift
+++ b/SubstrateSdk/Classes/Icon/Nova/NovaIconGenerator.swift
@@ -57,10 +57,11 @@ public final class NovaIconGenerator {
 
     private func deriveColors(from data: Data) -> (UIColor, UIColor) {
         let colors = Self.allColorPairs
-
-        let accountId: [UInt8] = data.map { $0 }
-        let index = (UInt(accountId[30]) + UInt(accountId[31]) * 256) % UInt(colors.count)
-
+        
+        let lastByteIndex = accountId.endIndex - 1
+        
+        let index = (UInt(accountId[lastByteIndex - 1]) + UInt(accountId[lastByteIndex]) * 256) % UInt(colors.count)
+        
         return colors[Int(index)]
     }
 }


### PR DESCRIPTION
### SUMMARY

This PR adds a safer approach to forming color indexes when deriving colors for accountId, preventing out-of-bounds crashes for 20-byte addresses.