### PR TITLE
Allow batching calls

### DIFF
--- a/SubstrateSdk.podspec
+++ b/SubstrateSdk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SubstrateSdk'
-  s.version          = '3.7.2'
+  s.version          = '3.7.3'
   s.summary          = 'Utility library that implements clients specific logic to interact with substrate based networks'
 
   s.homepage         = 'https://github.com/nova-wallet/substrate-sdk-ios'

--- a/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift
+++ b/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift
@@ -16,6 +16,7 @@ public protocol ExtrinsicBuilderProtocol: AnyObject {
     func adding(rawCall: Data) throws -> Self
     func adding(extrinsicSignedExtension: ExtrinsicSignedExtending) -> Self
     func wrappingCalls(for mapClosure: (JSON) throws -> JSON) throws -> Self
+    func batchingCalls(with metadata: RuntimeMetadataProtocol) throws -> Self
     func getCalls() -> [JSON]
     func reset() -> Self
     func signing(by signer: (Data) throws -> Data,
@@ -358,6 +359,14 @@ extension ExtrinsicBuilder: ExtrinsicBuilderProtocol {
     public func wrappingCalls(for mapClosure: (JSON) throws -> JSON) throws -> Self {
         let newCalls = try calls.map { try mapClosure($0) }
         self.calls = newCalls
+        return self
+    }
+    
+    public func batchingCalls(with metadata: RuntimeMetadataProtocol) throws -> Self {
+        let batchedCall = try prepareExtrinsicCall(for: metadata)
+
+        calls = [batchedCall]
+        
         return self
     }
 


### PR DESCRIPTION
## CHECKLIST

**Follow the checklist to help make your PR easier to review. Check off items as you complete them.**

- [ ] Did you review your own PR?

- [ ] Provide a SUMMARY description for this PR below.

- [ ] Provide a SOLUTION description for this PR below.

- [ ] Did you acknowledge all the feedback in this PR?


## SUMMARY

There are use cases when there is a need to batch calls beforehand. For example, wrapping into multisig.as_multi for final call.

## SOLUTION

Introduce a method that allows to batch current list of calls and save it in the builder