### PR TITLE
Replace scrypt crypto library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/attaswift/BigInt", exact: "5.5.1"),
         .package(url: "https://github.com/daisuke-t-jp/xxHash-Swift", exact: "1.1.1"),
         .package(url: "https://github.com/novasamatech/keccak.c", exact: "0.1.3"),
-        .package(url: "https://github.com/greymass/swift-scrypt", exact: "1.0.2"),
+        .package(url: "https://github.com/novasamatech/swift-scrypt", exact: "1.0.3"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubstrateSdk"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/novasamatech/Crypto-iOS", branch: "fix/scrypt-spm"),
+        .package(url: "https://github.com/novasamatech/Crypto-iOS", exact: "0.3.0"),
         .package(url: "https://github.com/novasamatech/Operation-iOS", exact: "2.1.1"),
         .package(url: "https://github.com/ashleymills/Reachability.swift", exact: "5.2.4"),
         .package(url: "https://github.com/novasamatech/Starscream.git", exact: "4.0.13"),

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["SubstrateSdk"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/novasamatech/Crypto-iOS", exact: "0.2.0"),
+        .package(url: "https://github.com/novasamatech/Crypto-iOS", branch: "fix/scrypt-spm"),
         .package(url: "https://github.com/novasamatech/Operation-iOS", exact: "2.1.1"),
         .package(url: "https://github.com/ashleymills/Reachability.swift", exact: "5.2.4"),
         .package(url: "https://github.com/novasamatech/Starscream.git", exact: "4.0.13"),
@@ -20,6 +20,7 @@ let package = Package(
         .package(url: "https://github.com/attaswift/BigInt", exact: "5.5.1"),
         .package(url: "https://github.com/daisuke-t-jp/xxHash-Swift", exact: "1.1.1"),
         .package(url: "https://github.com/novasamatech/keccak.c", exact: "0.1.3"),
+        .package(url: "https://github.com/greymass/swift-scrypt", exact: "1.0.2"),
     ],
     targets: [
         .target(
@@ -32,7 +33,8 @@ let package = Package(
                 .product(name: "TweetNacl", package: "tweetnacl-swiftwrap"),
                 .product(name: "BigInt", package: "BigInt"),
                 .product(name: "xxHash-Swift", package: "xxHash-Swift"),
-                .product(name: "keccak", package: "keccak.c")
+                .product(name: "keccak", package: "keccak.c"),
+                .product(name: "Scrypt", package: "swift-scrypt"),
             ],
             path: "SubstrateSdk/Classes"
         ),

--- a/SubstrateSdk/Classes/Keystore/KeystoreBuilder.swift
+++ b/SubstrateSdk/Classes/Keystore/KeystoreBuilder.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Scrypt
 import NovaCrypto
 import TweetNacl
 
@@ -30,16 +31,17 @@ extension KeystoreBuilder: KeystoreBuilding {
         let scryptParameters = try ScryptParameters()
 
         let scryptData: Data = try scryptData(from: password)
-
-        let encryptionKey = try IRScryptKeyDeriviation()
-            .deriveKey(
-                from: scryptData,
-                salt: scryptParameters.salt,
-                scryptN: UInt(scryptParameters.scryptN),
-                scryptP: UInt(scryptParameters.scryptP),
-                scryptR: UInt(scryptParameters.scryptR),
-                length: UInt(KeystoreConstants.encryptionKeyLength)
-            )
+        
+        let encryptionKeyBytes = try Scrypt.scrypt(
+            password: Array(scryptData),
+            salt: Array(scryptParameters.salt),
+            length: KeystoreConstants.encryptionKeyLength,
+            N: UInt64(scryptParameters.scryptN),
+            r: scryptParameters.scryptR,
+            p: scryptParameters.scryptP
+        )
+        
+        let encryptionKey = Data(encryptionKeyBytes)
 
         let nonce = try Data.generateRandomBytes(of: KeystoreConstants.nonceLength)
 

--- a/SubstrateSdk/Classes/Keystore/KeystoreExtractor.swift
+++ b/SubstrateSdk/Classes/Keystore/KeystoreExtractor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Scrypt
 import NovaCrypto
 import TweetNacl
 
@@ -36,16 +37,17 @@ public class KeystoreExtractor: KeystoreExtracting {
             } else {
                 scryptData = Data()
             }
-
-            let encryptionKey = try IRScryptKeyDeriviation()
-                .deriveKey(
-                    from: scryptData,
-                    salt: scryptParameters.salt,
-                    scryptN: UInt(scryptParameters.scryptN),
-                    scryptP: UInt(scryptParameters.scryptP),
-                    scryptR: UInt(scryptParameters.scryptR),
-                    length: UInt(KeystoreConstants.encryptionKeyLength)
-                )
+            
+            let encryptionKeyBytes = try Scrypt.scrypt(
+                password: Array(scryptData),
+                salt: Array(scryptParameters.salt),
+                length: KeystoreConstants.encryptionKeyLength,
+                N: UInt64(scryptParameters.scryptN),
+                r: scryptParameters.scryptR,
+                p: scryptParameters.scryptP
+            )
+            
+            let encryptionKey = Data(encryptionKeyBytes)
 
             let nonceStart = ScryptParameters.encodedLength
             let nonceEnd = ScryptParameters.encodedLength + KeystoreConstants.nonceLength


### PR DESCRIPTION
## CHECKLIST

**Follow the checklist to help make your PR easier to review. Check off items as you complete them.**

- [x] Did you review your own PR?

- [x] Provide a SUMMARY description for this PR below.

- [x] Provide a SOLUTION description for this PR below.

- [ ] Did you acknowledge all the feedback in this PR?


## SUMMARY

Previous scrypt crypto library contained broken implementation due to Xcode 15 changes. It were still worked via Cocoapods due to proper flags in OTHER_C_FLAGS arguments in the podspec. However with the SPM this doesn't work anymore.

## SOLUTION

The underlying C library was replaced with the other maintained solution - [libscrypt](https://github.com/technion/libscrypt)