### PR TITLE
Support query by prefix for double key operation

### DIFF
--- a/StorageQuery/StorageKeyEncodingOperation.swift
+++ b/StorageQuery/StorageKeyEncodingOperation.swift
@@ -175,8 +175,28 @@ public class DoubleMapKeyEncodingOperation<T1: Encodable, T2: Encodable>: BaseOp
         ) else {
             throw StorageKeyEncodingOperationError.invalidStoragePath
         }
-
-        guard case let .doubleMap(doubleMapEntry) = entry.type else {
+        
+        let key1Type: String
+        let key1Hasher: StorageHasher
+        let key2Type: String
+        let key2Hasher: StorageHasher
+        
+        switch entry.type {
+        case let .doubleMap(doubleMapEntry):
+            key1Type = doubleMapEntry.key1
+            key1Hasher = doubleMapEntry.hasher
+            key2Type = doubleMapEntry.key2
+            key2Hasher = doubleMapEntry.key2Hasher
+        case let .nMap(nMapEntry):
+            guard nMapEntry.keyVec.count >= 2, nMapEntry.hashers.count >= 2 else {
+                throw StorageKeyEncodingOperationError.incompatibleStorageType
+            }
+            
+            key1Type = nMapEntry.keyVec[0]
+            key1Hasher = nMapEntry.hashers[0]
+            key2Type = nMapEntry.keyVec[1]
+            key2Hasher = nMapEntry.hashers[1]
+        case .plain, .map:
             throw StorageKeyEncodingOperationError.incompatibleStorageType
         }
 
@@ -189,7 +209,7 @@ public class DoubleMapKeyEncodingOperation<T1: Encodable, T2: Encodable>: BaseOp
                 encodedParam1 = try encodeParam(
                     param.0,
                     factory: factory,
-                    type: doubleMapEntry.key1
+                    type: key1Type
                 )
             }
 
@@ -201,7 +221,7 @@ public class DoubleMapKeyEncodingOperation<T1: Encodable, T2: Encodable>: BaseOp
                 encodedParam2 = try encodeParam(
                     param.1,
                     factory: factory,
-                    type: doubleMapEntry.key2
+                    type: key2Type
                 )
             }
 
@@ -209,9 +229,9 @@ public class DoubleMapKeyEncodingOperation<T1: Encodable, T2: Encodable>: BaseOp
                 moduleName: path.moduleName,
                 storageName: path.itemName,
                 key1: encodedParam1,
-                hasher1: doubleMapEntry.hasher,
+                hasher1: key1Hasher,
                 key2: encodedParam2,
-                hasher2: doubleMapEntry.key2Hasher
+                hasher2: key2Hasher
             )
         }
 

--- a/SubstrateSdk/Classes/Scale/DynamicScaleCodingError.swift
+++ b/SubstrateSdk/Classes/Scale/DynamicScaleCodingError.swift
@@ -29,4 +29,5 @@ public enum DynamicScaleDecoderError: Error {
     case unexpectedOption(byte: UInt8)
     case unexpectedEnumCase
     case invalidEnumCase(value: Int, count: Int)
+    case invalidVectorLength
 }

--- a/SubstrateSdk/Classes/Scale/DynamicScaleDecoder.swift
+++ b/SubstrateSdk/Classes/Scale/DynamicScaleDecoder.swift
@@ -113,6 +113,10 @@ extension DynamicScaleDecoder: DynamicScaleDecoding {
         }
 
         let length = try BigUInt(scaleDecoder: decoder)
+        
+        guard length <= Int.max else {
+            throw DynamicScaleDecoderError.invalidVectorLength
+        }
 
         let jsons = try (0 ..< length).map { _ in try node.accept(decoder: self) }
 


### PR DESCRIPTION
## CHECKLIST

**Follow the checklist to help make your PR easier to review. Check off items as you complete them.**

- [x] Did you review your own PR?

- [x] Provide a SUMMARY description for this PR below.

- [x] Provide a SOLUTION description for this PR below.

- [ ] Did you acknowledge all the feedback in this PR?


## SUMMARY

**DoubleMapKeyEncodingOperation** currently has a check that prevents it from using for fetching by prefix when the actual key is nMap.

## SOLUTION

- adopt **DoubleMapKeyEncodingOperation** to properly support prefix similar to **MapKeyEncodingOperation**
- add check when decoding a vector dynamically to prevent crash