### PR TITLE
Fix array scale decoding crash

### DIFF
--- a/SubstrateSdk/Classes/Scale/Encodable/Array+Scale.swift
+++ b/SubstrateSdk/Classes/Scale/Encodable/Array+Scale.swift
@@ -26,12 +26,6 @@ extension Array: ScaleDecodable where Element: ScaleDecodable {
             throw ScaleCodingError.unexpectedDecodedValue
         }
 
-        // allocate memory only if en element is successfully decoded
-        var result = [Element]()
-        for _ in 0 ..< count {
-            result.append(try Element(scaleDecoder: scaleDecoder))
-        }
-        
-        self = result
+        self = try (0 ..< count).map { _ in try Element(scaleDecoder: scaleDecoder) }
     }
 }

--- a/SubstrateSdk/Classes/Scale/Encodable/Array+Scale.swift
+++ b/SubstrateSdk/Classes/Scale/Encodable/Array+Scale.swift
@@ -21,6 +21,17 @@ extension Array: ScaleDecodable where Element: ScaleDecodable {
 
         let count = Int(bigCount)
 
-        self = try (0 ..< count).map { _ in try Element(scaleDecoder: scaleDecoder) }
+        // we should have at least `count` bytes remained otherwise the data is malicious
+        guard count <= scaleDecoder.remained else {
+            throw ScaleCodingError.unexpectedDecodedValue
+        }
+
+        // allocate memory only if en element is successfully decoded
+        var result = [Element]()
+        for _ in 0 ..< count {
+            result.append(try Element(scaleDecoder: scaleDecoder))
+        }
+        
+        self = result
     }
 }

--- a/SubstrateSdk/Classes/Scale/Encodable/Data+Scale.swift
+++ b/SubstrateSdk/Classes/Scale/Encodable/Data+Scale.swift
@@ -1,14 +1,21 @@
 import Foundation
+import BigInt
 
 extension Data: ScaleCodable {
     public init(scaleDecoder: ScaleDecoding) throws {
-        let byteArray = try [UInt8](scaleDecoder: scaleDecoder)
-        self = Data(byteArray)
+        let bigCount = try BigUInt(scaleDecoder: scaleDecoder)
+
+        guard bigCount <= Int.max else {
+            throw ScaleCodingError.unexpectedDecodedValue
+        }
+
+        let count = Int(bigCount)
+        self = try scaleDecoder.readAndConfirm(count: count)
     }
 
     public func encode(scaleEncoder: ScaleEncoding) throws {
-        let byteArray: [UInt8] = map { $0 }
-        try byteArray.encode(scaleEncoder: scaleEncoder)
+        try BigUInt(count).encode(scaleEncoder: scaleEncoder)
+        scaleEncoder.appendRaw(data: self)
     }
 }
 

--- a/SubstrateSdk/Classes/Scale/Encodable/String+Scale.swift
+++ b/SubstrateSdk/Classes/Scale/Encodable/String+Scale.swift
@@ -12,20 +12,11 @@ extension String: ScaleCodable {
             throw ScaleStringError.unexpectedEncoding
         }
 
-        try BigUInt(data.count).encode(scaleEncoder: scaleEncoder)
-        scaleEncoder.appendRaw(data: data)
+        try data.encode(scaleEncoder: scaleEncoder)
     }
 
     public init(scaleDecoder: ScaleDecoding) throws {
-        let bigCount = try BigUInt(scaleDecoder: scaleDecoder)
-
-        guard bigCount <= Int.max else {
-            throw ScaleCodingError.unexpectedDecodedValue
-        }
-
-        let count = Int(bigCount)
-        let data = try scaleDecoder.read(count: count)
-        try scaleDecoder.confirm(count: count)
+        let data = try Data(scaleDecoder: scaleDecoder)
 
         guard let result = String(data: data, encoding: .utf8) else {
             throw ScaleStringError.unexpectedDecoding

--- a/Tests/Scale/ScaleArrayTests.swift
+++ b/Tests/Scale/ScaleArrayTests.swift
@@ -45,6 +45,23 @@ class ScaleArrayTests: XCTestCase {
         XCTAssertEqual(decoded, original)
     }
 
+    func testArrayCountExceedingRemainedBytesThrowsError() throws {
+        let encoder = ScaleEncoder()
+        try BigUInt(1_000_000_000).encode(scaleEncoder: encoder)
+
+        var data = encoder.encode()
+        data.append(contentsOf: [0x01, 0x02])
+
+        let decoder = try ScaleDecoder(data: data)
+
+        XCTAssertThrowsError(try [UInt8](scaleDecoder: decoder)) { error in
+            XCTAssertTrue(
+                error is ScaleCodingError,
+                "Expected ScaleCodingError but got \(error)"
+            )
+        }
+    }
+
     func testMaliciousArrayLengthExceedingUIntMaxThrowsError() throws {
         // Construct compact-encoded BigUInt = 2^64 (UInt.max + 1 on 64-bit)
         // Mode 0b11 (big integer): header = (byteCount - 4) << 2 | 0b11


### PR DESCRIPTION
## Purpose

The PR fixes an issue when malicious data contains broken array with huge count prefix. That cause decoded to preallocate a lot of memory and crash due to OOM. To overcome the problem:

- add check that data contains at least decoded `count` remained bytes
- allocate memory only after array's element is successfully decoded