### PR TITLE
Fix inherited implication byte for v4 extrinsics

### DIFF
--- a/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift
+++ b/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift
@@ -300,7 +300,7 @@ private extension ExtrinsicBuilder {
         implication: TransactionExtension.Implication,
         encodingFactory: DynamicScaleEncodingFactoryProtocol
     ) throws -> Data {
-        let signaturePayloadFactory: ExtrinsicSignaturePayloadFactoryProtocol = ExtrinsicSignaturePayloadFactory(
+        let signaturePayloadFactory = ImplicationSignaturePayloadFactory(
             extrinsicVersion: extrinsicVersion,
             mode: .extrinsicSignature
         )

--- a/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift
+++ b/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift
@@ -300,7 +300,10 @@ private extension ExtrinsicBuilder {
         implication: TransactionExtension.Implication,
         encodingFactory: DynamicScaleEncodingFactoryProtocol
     ) throws -> Data {
-        let signaturePayloadFactory = ExtrinsicSignaturePayloadFactory(extrinsicVersion: extrinsicVersion)
+        let signaturePayloadFactory: ExtrinsicSignaturePayloadFactoryProtocol = ExtrinsicSignaturePayloadFactory(
+            extrinsicVersion: extrinsicVersion,
+            mode: .extrinsicSignature
+        )
 
         return try signaturePayloadFactory.createPayload(
             from: implication,

--- a/SubstrateSdk/Classes/Extrinsic/ExtrinsicSignaturePayloadFactory.swift
+++ b/SubstrateSdk/Classes/Extrinsic/ExtrinsicSignaturePayloadFactory.swift
@@ -8,10 +8,32 @@ public protocol ExtrinsicSignaturePayloadFactoryProtocol {
 }
 
 public final class ExtrinsicSignaturePayloadFactory {
+    // New tx pipeline always requires version byte
+    // This is a fallback for v4 extrinsics
+    static let v4ExtrinsicVersion: UInt8 = 0
+    
+    public enum Mode {
+        case txExtensionPipeline
+        case extrinsicSignature
+    }
+    
     let extrinsicVersion: Extrinsic.Version
+    let mode: Mode
 
-    public init(extrinsicVersion: Extrinsic.Version) {
+    public init(extrinsicVersion: Extrinsic.Version, mode: Mode) {
         self.extrinsicVersion = extrinsicVersion
+        self.mode = mode
+    }
+}
+
+private extension ExtrinsicSignaturePayloadFactory {
+    func appendV4VersionIfNeeded(into encoder: DynamicScaleEncoding) throws {
+        switch mode {
+        case .txExtensionPipeline:
+            try encoder.append(encodable: Self.v4ExtrinsicVersion)
+        case .extrinsicSignature:
+            break
+        }
     }
 }
 
@@ -26,7 +48,7 @@ extension ExtrinsicSignaturePayloadFactory: ExtrinsicSignaturePayloadFactoryProt
         case let .V5(extensionVersion):
             try encoder.append(encodable: extensionVersion)
         case .V4:
-            break
+            try appendV4VersionIfNeeded(into: encoder)
         }
 
         try encoder.append(json: implication.call, type: GenericType.call.name)

--- a/SubstrateSdk/Classes/Extrinsic/ImplicationSignaturePayloadFactory.swift
+++ b/SubstrateSdk/Classes/Extrinsic/ImplicationSignaturePayloadFactory.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-public protocol ExtrinsicSignaturePayloadFactoryProtocol {
+public protocol ImplicationSignaturePayloadFactoryProtocol {
     func createPayload(
         from implication: TransactionExtension.Implication,
         using encodingFactory: DynamicScaleEncodingFactoryProtocol
     ) throws -> Data
 }
 
-public final class ExtrinsicSignaturePayloadFactory {
+public final class ImplicationSignaturePayloadFactory {
     // New tx pipeline always requires version byte
     // This is a fallback for v4 extrinsics
     static let v4ExtrinsicVersion: UInt8 = 0
@@ -20,13 +20,13 @@ public final class ExtrinsicSignaturePayloadFactory {
     let extrinsicVersion: Extrinsic.Version
     let mode: Mode
 
-    public init(extrinsicVersion: Extrinsic.Version, mode: Mode) {
+    public init(extrinsicVersion: Extrinsic.Version, mode: Mode = .txExtensionPipeline) {
         self.extrinsicVersion = extrinsicVersion
         self.mode = mode
     }
 }
 
-private extension ExtrinsicSignaturePayloadFactory {
+private extension ImplicationSignaturePayloadFactory {
     func appendV4VersionIfNeeded(into encoder: DynamicScaleEncoding) throws {
         switch mode {
         case .txExtensionPipeline:
@@ -37,7 +37,7 @@ private extension ExtrinsicSignaturePayloadFactory {
     }
 }
 
-extension ExtrinsicSignaturePayloadFactory: ExtrinsicSignaturePayloadFactoryProtocol {
+extension ImplicationSignaturePayloadFactory: ImplicationSignaturePayloadFactoryProtocol {
     public func createPayload(
         from implication: TransactionExtension.Implication,
         using encodingFactory: DynamicScaleEncodingFactoryProtocol

--- a/SubstrateSdk/Classes/Extrinsic/ParitySignerSignaturePayloadFactory.swift
+++ b/SubstrateSdk/Classes/Extrinsic/ParitySignerSignaturePayloadFactory.swift
@@ -8,7 +8,7 @@ public final class ParitySignerSignaturePayloadFactory {
     }
 }
 
-extension ParitySignerSignaturePayloadFactory: ExtrinsicSignaturePayloadFactoryProtocol {
+extension ParitySignerSignaturePayloadFactory: ImplicationSignaturePayloadFactoryProtocol {
     public func createPayload(
         from implication: TransactionExtension.Implication,
         using encodingFactory: DynamicScaleEncodingFactoryProtocol

--- a/SubstrateSdk/Classes/Extrinsic/TransactionExtension/Extensions/VerifySignature.swift
+++ b/SubstrateSdk/Classes/Extrinsic/TransactionExtension/Extensions/VerifySignature.swift
@@ -10,7 +10,10 @@ public extension TransactionExtension {
             usability: Usability
         ) {
             self.usability = usability
-            signaturePayloadFactory = ExtrinsicSignaturePayloadFactory(extrinsicVersion: extrinsicVersion)
+            signaturePayloadFactory = ExtrinsicSignaturePayloadFactory(
+                extrinsicVersion: extrinsicVersion,
+                mode: .txExtensionPipeline
+            )
         }
     }
 }

--- a/SubstrateSdk/Classes/Extrinsic/TransactionExtension/Extensions/VerifySignature.swift
+++ b/SubstrateSdk/Classes/Extrinsic/TransactionExtension/Extensions/VerifySignature.swift
@@ -3,17 +3,14 @@ import Foundation
 public extension TransactionExtension {
     final class VerifySignature {
         public let usability: VerifySignature.Usability
-        public let signaturePayloadFactory: ExtrinsicSignaturePayloadFactoryProtocol
+        public let signaturePayloadFactory: ImplicationSignaturePayloadFactoryProtocol
 
         public init(
             extrinsicVersion: Extrinsic.Version,
             usability: Usability
         ) {
             self.usability = usability
-            signaturePayloadFactory = ExtrinsicSignaturePayloadFactory(
-                extrinsicVersion: extrinsicVersion,
-                mode: .txExtensionPipeline
-            )
+            signaturePayloadFactory = ImplicationSignaturePayloadFactory(extrinsicVersion: extrinsicVersion)
         }
     }
 }


### PR DESCRIPTION
## Purpose

Current implementation doesn't take into account that  tx extension pipeline always requires extension version byte to be included into the payload and current implementation doesn't provided it for v4 extrinsics. The PR closes that gap for tx extension pipeline but living v4 signature payload format without byte inclusion.
