### PR TITLE
Support resendOnReconnect for subscriptions

### DIFF
--- a/.claude/docs/README.md
+++ b/.claude/docs/README.md
@@ -1,0 +1,43 @@
+# Documentation Index
+
+> **Lazy-load model** — load only the docs relevant to the current task.
+> Read the routing table below, then `Read` specific files as needed.
+> The high-level subsystem map and build/test commands live in `AGENTS.md`
+> (repo root); these docs go one level deeper on individual subsystems.
+
+## Routing Table
+
+| If the task involves...                                            | Load                     |
+|-------------------------------------------------------------------|--------------------------|
+| Overall layout, targets, build/test commands, conventions         | `../../AGENTS.md`        |
+| WebSocket connection lifecycle, JSON-RPC transport, reconnection, node switching, subscriptions, batching, health/ping | `web-socket-engine.md` |
+
+_As new subsystem docs are added (SCALE codec, runtime metadata, extrinsic
+building, crypto/keystore…), give each its own file here and add a routing row._
+
+## Glossary of Load-Bearing Terms
+
+These terms carry specific meaning across the SDK. Use them precisely:
+
+| Term            | Meaning                                                                                          |
+|-----------------|--------------------------------------------------------------------------------------------------|
+| Engine          | A `JSONRPCEngine` implementation — the transport clients call to send RPC/subscriptions (`WebSocketEngine`, `HTTPEngine`) |
+| Local id        | `UInt16` request id the SDK generates and returns to callers; used to cancel/track a request     |
+| Remote id       | Subscription id string assigned by the node after a successful `*_subscribe` call                |
+| Idempotent request | A request with `resendOnReconnect: true` — safe to replay after a drop (all subscriptions are) |
+| Node switching  | Rotating `selectedURL` to the next entry in `urls` when a node is down or returns a switch-worthy error |
+| Coder factory   | `RuntimeCoderFactory` — the SCALE coder/metadata provider most subsystems route through           |
+
+## Reference Material
+
+- `AGENTS.md` — repo-root guidance (layout, build/test, conventions); always start here
+- `Package.swift` — targets, products, dependencies, test resources
+- `SubstrateSdk/Classes/Network/` — networking source (engines, factories, strategies)
+
+## Recently Changed
+
+Most recent substantive doc-affecting changes. Older entries fall off as new ones land.
+
+- **2026-07-01** — Added `web-socket-engine.md` documenting the `WebSocketEngine`
+  transport (state machine, request/subscription/batch tracking, reconnection,
+  node switching, health checks). Initial `.claude/docs/` index created.

--- a/.claude/docs/README.md
+++ b/.claude/docs/README.md
@@ -39,6 +39,11 @@ These terms carry specific meaning across the SDK. Use them precisely:
 
 Most recent substantive doc-affecting changes. Older entries fall off as new ones land.
 
+- **2026-07-01** — `subscribe(...)` gained an `options: JSONRPCOptions` parameter.
+  `resendOnReconnect: false` marks a subscription non-idempotent so it is cancelled
+  (not replayed) on reconnect — the subscriber is notified `unsubscribed: true`.
+  Default stays `true`; existing call sites unchanged. See `web-socket-engine.md`.
+
 - **2026-07-01** — Added reusable mocks under `Tests/Helpers/Mocks/`
   (`MockWebSocketTransport` — a Starscream `Engine` mock — plus connection
   factory, engine delegate, reconnection stub) and

--- a/.claude/docs/README.md
+++ b/.claude/docs/README.md
@@ -10,6 +10,7 @@
 | If the task involves...                                            | Load                     |
 |-------------------------------------------------------------------|--------------------------|
 | Overall layout, targets, build/test commands, conventions         | `../../AGENTS.md`        |
+| Writing/running tests, XCTest→Swift Testing policy, test targets, fixtures | `tests.md`      |
 | WebSocket connection lifecycle, JSON-RPC transport, reconnection, node switching, subscriptions, batching, health/ping | `web-socket-engine.md` |
 
 _As new subsystem docs are added (SCALE codec, runtime metadata, extrinsic
@@ -38,6 +39,15 @@ These terms carry specific meaning across the SDK. Use them precisely:
 
 Most recent substantive doc-affecting changes. Older entries fall off as new ones land.
 
+- **2026-07-01** — Added reusable mocks under `Tests/Helpers/Mocks/`
+  (`MockWebSocketTransport` — a Starscream `Engine` mock — plus connection
+  factory, engine delegate, reconnection stub) and
+  `Tests/Network/WebSocketEngineTests.swift` (Swift Testing, 15 cases). Mocks
+  policy: reuse/extend shared mocks in `TestHelpers` before writing new ones
+  (`tests.md` §Mocks). See `web-socket-engine.md` (Tests).
+- **2026-07-01** — Added `tests.md`. Test-framework policy: **new tests use
+  Swift Testing**, existing XCTest stays and is migrated opportunistically when a
+  file is otherwise changed.
 - **2026-07-01** — Added `web-socket-engine.md` documenting the `WebSocketEngine`
   transport (state machine, request/subscription/batch tracking, reconnection,
   node switching, health checks). Initial `.claude/docs/` index created.

--- a/.claude/docs/tests.md
+++ b/.claude/docs/tests.md
@@ -1,0 +1,141 @@
+# Tests
+
+## Framework policy — read first
+
+- **New tests: use [Swift Testing](https://developer.apple.com/documentation/testing)**
+  (`import Testing`, `@Test`, `#expect`, `#require`, `@Suite`).
+- **Existing tests stay on XCTest.** Do not do a big-bang migration.
+- **Migrate opportunistically:** when you meaningfully change an existing
+  XCTest case, port that file (or the cases you touch) to Swift Testing as part
+  of the same change. Leave untouched files alone.
+- Both frameworks run in the same target/bundle side by side, so a target can
+  hold a mix during the transition — no target split needed.
+
+## Test targets
+
+Defined in `Package.swift`; one test target per subsystem, each a directory
+under `Tests/`:
+
+| Target                  | Path                     | Resources                     |
+|-------------------------|--------------------------|-------------------------------|
+| `CommonTests`           | `Tests/Common`           | —                             |
+| `CryptoTests`           | `Tests/Crypto`           | HDKD vectors                  |
+| `ExtrinsicBuilderTests` | `Tests/ExtrinsicBuilder` | —                             |
+| `IconTests`             | `Tests/Icon`             | —                             |
+| `JsonTests`             | `Tests/JSON`             | —                             |
+| `KeystoreTests`         | `Tests/Keystore`         | keystore JSON                 |
+| `NetworkTests`          | `Tests/Network`          | —                             |
+| `QRTests`               | `Tests/QR`               | —                             |
+| `RuntimeTests`          | `Tests/Runtime`          | runtime metadata blobs        |
+| `ScaleTests`            | `Tests/Scale`            | —                             |
+
+`TestHelpers` (`Tests/Helpers`) is a **library target, not a test target** —
+shared fixtures and helpers (`RuntimeHelpers`, `KeypairDeriviation`,
+`JSONHelpers`, `PostV14RuntimeHelper`), reusable mocks (`Mocks/`, see below), and
+the runtime resources. Test targets depend on it. Fixtures live in `Tests/Resources/` and `Resources/`, wired via
+the `Resources` enum at the bottom of `Package.swift` — register any new
+resource file there.
+
+## Running tests
+
+iOS-only package → run via `xcodebuild` against a simulator (plain `swift test`
+won't work, there is no macOS platform):
+
+```bash
+# All package tests
+xcodebuild test -scheme SubstrateSdk \
+  -destination 'platform=iOS Simulator,name=iPhone 15'
+
+# A single target
+xcodebuild test -scheme SubstrateSdk \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  -only-testing:ScaleTests
+
+# A single Swift Testing / XCTest case
+xcodebuild test -scheme SubstrateSdk \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
+  -only-testing:ScaleTests/FixedArrayTests
+```
+
+There is no CI workflow in this repo yet (`.github/` holds only the PR
+template) — run tests locally before opening a PR.
+
+## Writing new tests (Swift Testing)
+
+Canonical shape — a suite with a throwing, tagged test using Given / When / Then:
+
+```swift
+import Testing
+import Foundation
+@testable import SubstrateSdk
+
+@Suite("Storage key factory")
+struct StorageKeyFactoryTests {
+    @Test("blake128Concat key matches known vector")
+    func createsExpectedKeyForBlake128ConcatHasher() throws {
+        // Given
+        let factory = StorageKeyFactory()
+        let identifier = try Data(hexString: "8ad2a3fba7…")
+
+        // When
+        let key = try factory.createStorageKey(
+            moduleName: "System",
+            storageName: "Account",
+            key: identifier,
+            hasher: .blake128Concat
+        )
+
+        // Then
+        #expect(key == (try Data(hexString: "0x26aa394e…")))
+    }
+}
+```
+
+Conventions:
+- `#expect(...)` for assertions; `try #require(...)` to unwrap/guard before
+  continuing (replaces `XCTUnwrap` and the `guard … else { XCTFail }` pattern).
+- Prefer **throwing tests** (`func … throws`) over the old
+  `do { … } catch { XCTFail("\(error)") }` wrapper — a thrown error fails the
+  test with the error automatically.
+- Use **parameterized tests** instead of loops or copy-pasted cases:
+  `@Test(arguments: [...])`.
+- Test-method names are plain camelCase describing behavior; the human-readable
+  intent goes in the `@Test("…")` / `@Suite("…")` display name.
+- Group related tests in a `@Suite` `struct` (value-type, fresh instance per
+  test → natural isolation; use `init`/`deinit` for setup/teardown).
+
+## Mocks
+
+Reusable test doubles live in **`Tests/Helpers/Mocks/`** (part of the shared
+`TestHelpers` target), one type per file, declared `public` so any test target
+can use them.
+
+- **Reuse or extend a shared mock before writing a new one.** If a shared mock is
+  close but missing something, add the capability there (a new recorded field, a
+  new `simulate…` helper) rather than forking a private copy into your suite.
+- **Only fall back to a local double when the need is genuinely suite-specific**
+  — and if it later proves reusable, promote it into `Tests/Helpers/Mocks/`.
+- **Mock at the right seam.** Prefer mocking the lowest-level injectable protocol
+  and exercising the real production types above it, over faking a whole
+  high-level object. That keeps the real code paths under test.
+- Keep mocks dumb: record inputs and expose simple accessors / `simulate…`
+  helpers; put behavior/assertions in the test, not the mock.
+
+## Test-data conventions
+
+- Use `Data(hexString:)` for hex fixtures and `Data.random` / `Data.randomOrError`
+  (from `SubstrateSdk`) for random bytes — not ad-hoc byte arrays.
+- Load runtime metadata / keystore fixtures through the `TestHelpers` helpers
+  rather than re-reading resource files inline.
+- Use `@testable import SubstrateSdk` to reach internal types (most existing
+  tests do).
+
+## Hard rules
+
+1. **New code ships with new tests** — and those tests are Swift Testing.
+2. **Test behavior, not implementation** — assert on public outputs; only reach
+   for `@testable` internals when there is no observable surface.
+3. **Register fixtures in `Package.swift`** (`Resources` enum) — an unregistered
+   resource silently isn't bundled and the test fails only at runtime.
+4. **Don't churn passing XCTest files** just to change framework — migrate a
+   file only when you're already editing it.

--- a/.claude/docs/web-socket-engine.md
+++ b/.claude/docs/web-socket-engine.md
@@ -1,0 +1,158 @@
+# WebSocketEngine
+
+The default `JSONRPCEngine` transport for talking to a Substrate node over a
+WebSocket. Owns a single live socket, a connection state machine, request /
+subscription / batch bookkeeping, automatic reconnection, multi-URL node
+switching, and periodic health checks.
+
+**Source:** `SubstrateSdk/Classes/Network/`
+- `WebSocketEngine.swift` — core: state, init, connect/disconnect, request & subscription bookkeeping, reconnection/node-switch, ping
+- `WebSocketEngine+Protocol.swift` — the public `JSONRPCEngine` conformance (`callMethod`, `subscribe`, batch, cancel)
+- `WebSocketEngine+Delegate.swift` — Starscream `WebSocketDelegate`, reachability, and scheduler callbacks
+- `JSONRPCEngine.swift` — protocol, request/subscription/batch model types, `JSONRPCOptions`, errors
+- `WebSocketConnectionFactory.swift` — builds the underlying Starscream `WebSocket`
+- `ReconnectionStrategy.swift` — `ExponentialReconnection`
+- `JSONRPCNodeSwitching.swift` — error-code-driven node switching
+- `Health.swift` / `RPCMethod.swift` — `HealthCheckMethod`, `system_health`, `state_unsubscribeStorage`
+
+## Responsibilities
+
+- Maintain one WebSocket connection to `selectedURL`, one of an ordered `urls` list.
+- Expose the `JSONRPCEngine` API: `callMethod`, `subscribe`, batching, `cancelForIdentifiers`.
+- Queue requests issued while disconnected/connecting and flush them on connect.
+- Track in-flight requests and active subscriptions so they survive drops.
+- Reconnect with backoff; rotate to the next node when one looks down or returns a switch-worthy error.
+- Keep the socket alive with pings (WebSocket ping/pong or a Substrate `system_health` call).
+
+## Connection state machine
+
+`WebSocketEngine.State` (Equatable):
+
+```
+notConnected(url:) ──connect──▶ connecting(url:) ──.connected event──▶ connected(url:)
+       ▲                              │                                      │
+       │                    error/cancel/disconnect                error/cancel/disconnect
+       │                              ▼                                      ▼
+       └───────── waitingReconnection(url:) ◀── scheduleReconnectionOrDisconnect ──┘
+```
+
+- **`notConnected`** — idle. A new request triggers `startConnecting`.
+- **`connecting`** — socket opening; requests are queued in `pendingRequests`.
+- **`connected`** — requests are written immediately; ping loop runs.
+- **`waitingReconnection`** — a reconnection is scheduled on `reconnectionScheduler`; a fresh request or network-reachable event cancels the wait and connects now.
+
+Every assignment to `state` fires `delegate.webSocketDidChangeState(_:from:to:)` on `completionQueue`.
+
+## Concurrency model
+
+- All public entry points and all delegate/scheduler callbacks take `mutex`
+  (`NSLock`) — mutation of engine state is fully serialized. **Do not call an
+  internal `WebSocketEngine` method without already holding `mutex`.**
+- Two dispatch queues (both default to the shared `JSONRPCEngineShared.processingQueue`,
+  label `com.nova.ws.processing`):
+  - `processingQueue` — where Starscream delivers socket events (the connection's
+    `callbackQueue`) and where the schedulers fire.
+  - `completionQueue` — where caller completion handlers, subscription updates,
+    and delegate callbacks are dispatched.
+- Because they default to the same serial queue, socket-event handling and
+  caller callbacks are serialized together. Passing a distinct `processingQueue`
+  separates them.
+
+## Lifecycle & public API
+
+Construction (`init?`) returns `nil` if `urls` is empty. Key knobs (with defaults):
+`connectionFactory` (`WebSocketConnectionFactory`), `customNodeSwitcher` (nil),
+`reachabilityManager` (nil), `reconnectionStrategy` (`ExponentialReconnection()`),
+`healthCheckMethod` (`.websocketPingPong`), `autoconnect` (`true`),
+`connectionTimeout` (10s), `pingInterval` (30s), `name`, `logger`. With
+`autoconnect` it calls `connectIfNeeded()` immediately.
+
+- **`connectIfNeeded()`** — connects from `notConnected`; from `waitingReconnection` cancels the timer and connects now; otherwise no-op.
+- **`disconnectIfNeeded(_ force:)`** — moves to `notConnected`, cancels in-flight work (see below), and either graceful-closes (`CloseCode.goingAway`) or hard-resets the socket.
+- **`changeUrls(_:)`** — disconnect, replace `urls`, reset `selectedURLIndex`/`reconnectionAttempts`, rebuild the connection, reconnect.
+- **`JSONRPCEngine` methods** (`WebSocketEngine+Protocol.swift`): `callMethod`, `subscribe`, `addBatchCallMethod`/`submitBatch`/`clearBatch`, `cancelForIdentifiers`. All lock `mutex`, generate a local id, and route through `updateConnectionForRequest`.
+- `deinit` detaches the delegate, force-disconnects, and cancels both schedulers.
+
+## Request routing (`updateConnectionForRequest`)
+
+Depending on `state`:
+- `connected` → `send(request:)` immediately.
+- `connecting` / `notConnected` → append to `pendingRequests` (and start connecting if `notConnected`).
+- `waitingReconnection` → append to pending, cancel the reconnection timer, and start connecting now (don't make a user request wait out the backoff).
+
+`send(request:)` records the request in `inProgressRequests` keyed by each item id
+(a batch registers all its item ids → the same request) and writes the JSON to the socket.
+On `connected`, `sendAllPendingRequests()` flushes the queue.
+
+## Local vs remote ids
+
+- **Local id** (`UInt16`) — generated by `generateRequestId()`, returned to the caller, used to cancel/track. `generateRequestId` avoids collisions with all pending, in-progress, subscription, and partial-batch ids.
+- **Remote id** (`String`) — a subscription id the node returns in the response to a `*_subscribe` call. Stored on the `JSONRPCSubscribing` as `remoteId`; subsequent update notifications are matched by remote id.
+
+## Incoming data (`process(data:)`)
+
+1. Try to decode a single `JSONRPCBasicData`:
+   - has an `identifier` + `error` → `processErrorAndResetIfNeeded`;
+   - has an `identifier`, no error → `completeRequestForRemoteId` (fulfils a request and/or captures a subscription's remote id);
+   - no `identifier` → it's a subscription update → `processSubscriptionUpdate`.
+2. Otherwise decode a JSON array (batch response), split into per-item responses keyed by id, complete each, then run `processErrorsInBatch`.
+
+**Subscription-update ordering race:** a subscription update can arrive *before*
+the `*_subscribe` response that tells us the remote id. `processSubscriptionUpdate`
+handles this by buffering updates for an unknown remote id in
+`pendingSubscriptionResponses[remoteId]`; when the subscribe response lands,
+`processSubscriptionResponse` replays the buffered updates. Preserve this buffering.
+
+## Reconnection & node switching
+
+`scheduleReconnectionOrDisconnect(attempt:after:)` is the hub:
+- If `attempt > 1` the current node is treated as down → `switchNode()` (rotate `selectedURL`), and the returned attempt count is used.
+- Ask `reconnectionStrategy.reconnectAfter(attempt:)`. If it returns a delay → state `waitingReconnection`, arm `reconnectionScheduler`. If it returns `nil` (give up) → state `notConnected` and every pending request is failed with the error (or `JSONRPCEngineError.unknownError`).
+- `ExponentialReconnection.reconnectAfter` = `multiplier * exp(attempt)` (default multiplier `0.3`), and never returns nil, so by default the engine retries forever.
+
+`switchNode()` detaches/force-disconnects, advances `selectedURLIndex` modulo
+`urls.count`, rebuilds the connection, and — when `urls.count > 1` — notifies
+`delegate.webSocketDidSwitchURL`. Reconnection attempt counts are tracked
+per-URL in `reconnectionAttempts`.
+
+**Custom node switching by RPC error:** `JSONRPCNodeSwitching` /
+`JSONRRPCodeNodeSwitcher(codes:)` lets specific JSON-RPC error codes force an
+immediate node switch (`resetRequestsAndSwitchNode`) instead of surfacing the
+error to the caller. Wired through `processErrorAndResetIfNeeded`.
+
+**Reachability:** if a `reachabilityManager` is supplied and the network becomes
+reachable while in `waitingReconnection`, the engine cancels the backoff timer
+and reconnects immediately.
+
+## Resetting in-flight work on a drop (`resetInProgress`)
+
+On any disconnect/error/cancel while connected:
+- Requests with `resendOnReconnect: true` (idempotent) are moved back to `pendingRequests` to be replayed.
+- Requests with `resendOnReconnect: false` that have a response handler are returned as *notifiable* and failed with an error (`clientCancelled` / `remoteCancelled` / `unknownError` depending on cause).
+- `rescheduleActiveSubscriptions()` clears each active subscription's `remoteId` and re-queues its original subscribe request, so subscriptions transparently re-establish after reconnect. **Subscriptions always use `resendOnReconnect: true`.**
+
+## Health checks / ping
+
+While `connected`, `schedulePingIfNeeded()` arms `pingScheduler` every
+`pingInterval` (skipped if `pingInterval <= 0`). `sendPing()` dispatches per
+`healthCheckMethod`:
+- `.websocketPingPong` → `connection.write(ping:)`; inbound pings are answered with `write(pong:)`.
+- `.substrate` → a `system_health` RPC call (`resendOnReconnect: false`); the result only logs a warning if the node reports `isSyncing`.
+
+## Delegate
+
+`WebSocketEngineDelegate` (weak):
+- `webSocketDidChangeState(_:from:to:)` — every state transition.
+- `webSocketDidSwitchURL(_:newUrl:)` — only when a switch happens and `urls.count > 1`.
+
+## Extending / gotchas
+
+- **Hold `mutex`.** Public methods and delegate callbacks lock it; internal
+  helpers assume it's held. Adding a new public method → lock/`defer` unlock like the others.
+- **Respect `resendOnReconnect`.** It's the contract for what survives a drop.
+  Reads/subscriptions should be idempotent; one-shot side-effecting calls should not.
+- **Preserve the pending-subscription-response buffer** — removing it reintroduces the update-before-subscribe-ack race.
+- **Injection points for tests:** `WebSocketConnectionFactoryProtocol` (swap the
+  socket), `ReconnectionStrategyProtocol`, `JSONRPCNodeSwitching`,
+  `ReachabilityManagerProtocol`. `WebSocketConnectionProtocol` abstracts Starscream's `WebSocket`.
+- **State changes fire delegate callbacks on `completionQueue`** — don't assume they run inline with the mutation.

--- a/.claude/docs/web-socket-engine.md
+++ b/.claude/docs/web-socket-engine.md
@@ -145,6 +145,34 @@ While `connected`, `schedulePingIfNeeded()` arms `pingScheduler` every
 - `webSocketDidChangeState(_:from:to:)` — every state transition.
 - `webSocketDidSwitchURL(_:newUrl:)` — only when a switch happens and `urls.count > 1`.
 
+## Tests
+
+`Tests/Network/WebSocketEngineTests.swift` (Swift Testing) covers the engine
+end-to-end without a real socket. It mocks at the **correct seam**: Starscream's
+low-level `Engine` transport, not the whole `WebSocket`. The shared mocks live in
+`Tests/Helpers/Mocks/` (`TestHelpers` target):
+- `MockWebSocketTransport` implements Starscream's `Engine` — records outbound
+  frames (`sentRequests`, `pingCount`, `pongCount`) and lifecycle
+  (`startCount`, `stopCloseCodes`), and exposes `simulate…` helpers to push inbound events.
+- `MockWebSocketConnectionFactory` hands the SDK a **real** `WebSocket` built
+  around that transport, so the production `WebSocket` (state forwarding,
+  `callbackQueue` delivery) is exercised — only the wire is faked. It records
+  every connection in `transports` (use `latest` for the current one).
+- `MockWebSocketEngineDelegate`, `StubReconnectionStrategy` complete the wiring.
+
+**Synchronization:** the engine is built with a dedicated serial `processingQueue`.
+Pushing an event hops through the real `WebSocket` onto that queue and the engine
+re-dispatches completions onto it, so the `Harness` drains it with a few
+`queue.sync {}` passes before asserting. Passing your own queue (not the shared
+`JSONRPCEngineShared.processingQueue`) is what makes async delivery deterministic
+and keeps parallel tests isolated.
+
+Covered behaviors: nil init on empty urls, autoconnect, connect/queue/flush,
+success & error result delivery, subscription remote-id capture + update routing,
+unsubscribe on cancel, subscription replay across reconnect, give-up failing
+pending requests, node switching via `JSONRPCNodeSwitching`, graceful disconnect,
+inbound ping→pong.
+
 ## Extending / gotchas
 
 - **Hold `mutex`.** Public methods and delegate callbacks lock it; internal

--- a/.claude/docs/web-socket-engine.md
+++ b/.claude/docs/web-socket-engine.md
@@ -126,10 +126,16 @@ and reconnects immediately.
 
 ## Resetting in-flight work on a drop (`resetInProgress`)
 
-On any disconnect/error/cancel while connected:
+On any disconnect/error/cancel while connected, `resetInProgress()` clears the in-flight
+state and returns a `(requests, subscriptions)` tuple of what was **cancelled** (not
+replayed); the caller passes it to `notify(cancelled:error:)`, which delivers the
+context-appropriate error (`clientCancelled` / `remoteCancelled` / `unknownError`) to both.
+
 - Requests with `resendOnReconnect: true` (idempotent) are moved back to `pendingRequests` to be replayed.
-- Requests with `resendOnReconnect: false` that have a response handler are returned as *notifiable* and failed with an error (`clientCancelled` / `remoteCancelled` / `unknownError` depending on cause).
-- `rescheduleActiveSubscriptions()` clears each active subscription's `remoteId` and re-queues its original subscribe request, so subscriptions transparently re-establish after reconnect. **Subscriptions always use `resendOnReconnect: true`.**
+- Requests with `resendOnReconnect: false` that have a response handler are returned in the tuple and failed.
+- `resetActiveSubscriptions()` handles subscriptions by their `requestOptions.resendOnReconnect`:
+  - **Idempotent (`resendOnReconnect: true`, the default)** — clears `remoteId` and re-queues the original subscribe request, so the subscription transparently re-establishes after reconnect. (Not-yet-acked ones ride their in-flight subscribe request.)
+  - **Non-idempotent (`resendOnReconnect: false`)** — is **not** replayed (replaying e.g. `author_submitAndWatchExtrinsic` would resubmit the extrinsic). It is removed and returned in the tuple; `notify(cancelled:error:)` then invokes its failure closure with `unsubscribed: true` and the disconnect error, so the subscriber learns it won't be restored. Set this via the `options:` parameter on `subscribe(...)`.
 
 ## Health checks / ping
 
@@ -169,8 +175,9 @@ and keeps parallel tests isolated.
 
 Covered behaviors: nil init on empty urls, autoconnect, connect/queue/flush,
 success & error result delivery, subscription remote-id capture + update routing,
-unsubscribe on cancel, subscription replay across reconnect, give-up failing
-pending requests, node switching via `JSONRPCNodeSwitching`, graceful disconnect,
+unsubscribe on cancel, idempotent subscription replay across reconnect,
+non-idempotent subscription cancellation on reconnect, give-up failing pending
+requests, node switching via `JSONRPCNodeSwitching`, graceful disconnect,
 inbound ping→pong.
 
 ## Extending / gotchas

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ DerivedData
 # SPM
 
 .swiftpm
+.build/
 Package.resolved
 
 # Bundler

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,9 @@ not an app that consumes it. It provides SCALE codec, runtime metadata parsing,
 JSON-RPC networking, storage queries/subscriptions, extrinsic building/signing,
 crypto/keystore, and QR/identicon utilities.
 
+Deeper per-subsystem docs live in `.claude/docs/` — see `.claude/docs/README.md`
+for the routing table (lazy-load: read the index, then open only what the task needs).
+
 ## Layout
 
 Distributed as an SPM package only (`Package.swift`, swift-tools 6.0, Swift 5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,9 @@ Verify scheme names with `xcodebuild -list`.
 running the relevant `Tests/<Subsystem>` target. When adding a new test resource,
 register it in the `Resources` enum in `Package.swift`.
 
+**New tests use Swift Testing**; existing XCTest stays and is migrated
+opportunistically. See `.claude/docs/tests.md`.
+
 ## Conventions & rules
 
 These reflect how the SDK is meant to be used and extended (distilled from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,85 @@
+# AGENTS.md — substrate-sdk-ios
+
+Guidance for AI agents working **inside** this repository. This is the
+`SubstrateSdk` library itself (Nova Wallet's Substrate/Polkadot SDK for iOS) —
+not an app that consumes it. It provides SCALE codec, runtime metadata parsing,
+JSON-RPC networking, storage queries/subscriptions, extrinsic building/signing,
+crypto/keystore, and QR/identicon utilities.
+
+## Layout
+
+Distributed as an SPM package only (`Package.swift`, swift-tools 6.0, Swift 5
+language mode, iOS 14+). CocoaPods is no longer supported. Five products, each a
+top-level directory / SPM target:
+
+| Target (product)                | Path                 | Depends on                          | Purpose |
+|---------------------------------|----------------------|-------------------------------------|---------|
+| `SubstrateSdk`                  | `SubstrateSdk/Classes` | (core deps)                       | Core: SCALE, runtime, network, extrinsic, crypto, keystore, QR, icon |
+| `SubstrateStorageQuery`         | `StorageQuery`       | `SubstrateSdk`                      | One-shot & prefix storage reads (`StorageRequestFactory`) |
+| `SubstrateStorageSubscription`  | `StorageSubscription`| `SubstrateSdk`, `SubstrateStorageQuery` | Batched storage subscriptions (`CallbackBatchStorageSubscription`) |
+| `SubstrateStateCall`            | `StateCall`          | `SubstrateSdk`                      | Runtime API (`state_call`) execution |
+| `SubstrateMetadataHash`         | `MetadataHash`       | `SubstrateSdk`, metadata-shortener | CheckMetadataHash / metadata shortening |
+
+Core (`SubstrateSdk/Classes`) subsystems:
+- **Scale/** — `DynamicScaleEncoder`/`DynamicScaleDecoder`, `ScaleCodable`, per-type
+  encoders in `Scale/Encodable/`, SCALE types in `Scale/Types/` (Era, MultiAddress, H256…).
+- **Runtime/** — metadata parsing (`Metadata/V14`, `V15`, `PostV14`, `RuntimeApi`),
+  type registry & resolution (`TypeRegistry`, `TypeRegistryCatalog`, `SiTypeRegistry`),
+  `CodingFactory/RuntimeCoderFactory` (the coder factory everything routes through).
+- **Extrinsic/** — `ExtrinsicBuilder`, `RuntimeCall`, `CallBuilder/`, and
+  `TransactionExtension/` (signed extensions: CheckGenesis, CheckMortality,
+  CheckMetadataHash, ChargeTransactionPayment, ChargeAssetTxPayment, VerifySignature…).
+- **Network/** — `JSONRPCEngine`, `WebSocketEngine` (Starscream), `HTTPEngine`,
+  reconnection/node-switching, `Reachability`.
+- **Crypto/**, **Signing/**, **Keystore/** — keypair factories (sr25519/ed25519/ecdsa),
+  BIP32/junction derivation, signing wrappers, keystore encode/decode (Scrypt).
+- **Primitives/**, **Pallets/**, **QR/**, **Icon/** — AccountId/address helpers,
+  known pallet models (System, Utility, Orml…), Substrate QR codec, Polkadot/Nova identicons.
+
+Tests live in `Tests/` (one target per subsystem, see `Package.swift`). Fixtures
+are in `Resources/` (runtime metadata blobs, keystores, HDKD vectors) and wired
+via the `Resources` enum at the bottom of `Package.swift`.
+
+## Build & test
+
+iOS-only package, so use `xcodebuild` against a simulator (plain `swift test`
+won't work — there is no macOS platform):
+
+```bash
+# SPM (scheme `SubstrateSdk`; `SubstrateMetadataHash` is a separate scheme)
+xcodebuild test -scheme SubstrateSdk \
+  -destination 'platform=iOS Simulator,name=iPhone 15'
+```
+
+Verify scheme names with `xcodebuild -list`.
+
+`swift build` may succeed for dependency resolution, but validate real changes by
+running the relevant `Tests/<Subsystem>` target. When adding a new test resource,
+register it in the `Resources` enum in `Package.swift`.
+
+## Conventions & rules
+
+These reflect how the SDK is meant to be used and extended (distilled from
+downstream Nova Wallet review history):
+
+- **Route decoding through the coder factory.** New SCALE work should go through
+  `RuntimeCoderFactory`/`DynamicScaleDecoder`, not ad-hoc byte parsing. Implement
+  `ScaleEncodable`/`ScaleDecodable` at the type level for reuse rather than
+  decoding inline.
+- **Never silently fall back to raw bytes.** When decoding expectations aren't
+  met, throw an explicit error (see `DynamicScaleCodingError`, `ScaleCodingError`).
+- **Transaction-extension ordering matters.** Base/default extensions come first,
+  custom overrides after — a later extension must be able to override an earlier
+  one. Respect this when touching `ExtrinsicBuilder` / `TransactionExtension`.
+- **Hex conversion:** use the `Data` wrappers (`Data(hexString:)`, `Data.toHex(includePrefix:)`)
+  from `Primitives/Data+Hex.swift`, not the underlying `NSData` helpers from NovaCrypto.
+  Use `Data.random`/`Data.randomOrError` for test/random data.
+- **Match surrounding style.** Files are grouped by subsystem with `+`-suffixed
+  extension files (e.g. `RuntimeCall+JSON.swift`, `CallMetadata+TypeCheck.swift`).
+  New generic helpers belong in the subsystem they extend.
+
+## PRs
+
+Follow `.github/PULL_REQUEST_TEMPLATE.md` (SUMMARY + SOLUTION sections, self-review
+checkbox). Tag releases from `master` (the main branch); consumers pin the SDK by
+git tag / SPM version.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,9 @@ Verify scheme names with `xcodebuild -list`.
 running the relevant `Tests/<Subsystem>` target. When adding a new test resource,
 register it in the `Resources` enum in `Package.swift`.
 
+Running SPM (`swift build`/`swift test`) creates a `.build/` directory (git-ignored,
+hundreds of MB). Delete it when done — `rm -rf .build` — don't leave it in the tree.
+
 **New tests use Swift Testing**; existing XCTest stays and is migrated
 opportunistically. See `.claude/docs/tests.md`.
 
@@ -83,6 +86,10 @@ downstream Nova Wallet review history):
 - **Match surrounding style.** Files are grouped by subsystem with `+`-suffixed
   extension files (e.g. `RuntimeCall+JSON.swift`, `CallMetadata+TypeCheck.swift`).
   New generic helpers belong in the subsystem they extend.
+- **Keep comments minimal — code should be self-descriptive.** Prefer clear names
+  over narration; don't restate what the code does or describe behavior that tests
+  already cover. Reserve comments for non-obvious *why* (rationale, invariants,
+  gotchas).
 
 ## PRs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See @AGENTS.md for repository architecture, build/test commands, and coding conventions.

--- a/Package.swift
+++ b/Package.swift
@@ -98,7 +98,8 @@ let package = Package(
         .target(
             name: "TestHelpers",
             dependencies: [
-                "SubstrateSdk"
+                "SubstrateSdk",
+                .product(name: "Starscream", package: "Starscream")
             ],
             path: "Tests/Helpers",
             resources: Resources.runtimes()
@@ -160,6 +161,7 @@ let package = Package(
             name: "NetworkTests",
             dependencies: [
                 "SubstrateSdk",
+                "TestHelpers",
             ],
             path: "Tests/Network"
         ),

--- a/README.md
+++ b/README.md
@@ -1,18 +1,41 @@
 # Substrate SDK iOS
 
-## Example
-
-To run the example project, clone the repo, and run `pod install` from the Example directory first.
+Utility library that implements client-specific logic to interact with
+Substrate-based networks (SCALE codec, runtime metadata, JSON-RPC, storage
+queries/subscriptions, extrinsic building/signing, crypto/keystore, QR/identicons).
 
 ## Requirements
 
+- iOS 14.0+
+- Swift 5 language mode / Xcode with swift-tools 6.0
+
 ## Installation
 
-SubstrateSdk is available through [CocoaPods](https://cocoapods.org). To install
-it, simply add the following line to your Podfile:
+SubstrateSdk is distributed via [Swift Package Manager](https://www.swift.org/documentation/package-manager/)
+only. CocoaPods is no longer supported.
 
-```ruby
-pod 'SubstrateSdk', :git => 'https://github.com/nova-wallet/substrate-sdk-ios.git', :tag => '1.1.0'
+Add the package in Xcode (File → Add Package Dependencies…) using
+`https://github.com/nova-wallet/substrate-sdk-ios.git`, or add it to your
+`Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/nova-wallet/substrate-sdk-ios.git", from: "4.5.1")
+]
+```
+
+Then depend on the products you need:
+
+```swift
+.target(
+    name: "YourTarget",
+    dependencies: [
+        .product(name: "SubstrateSdk", package: "substrate-sdk-ios"),
+        // optional additional products:
+        // "SubstrateStorageQuery", "SubstrateStorageSubscription",
+        // "SubstrateStateCall", "SubstrateMetadataHash"
+    ]
+)
 ```
 
 ## Author

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the package in Xcode (File → Add Package Dependencies…) using
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/nova-wallet/substrate-sdk-ios.git", from: "4.5.1")
+    .package(url: "https://github.com/nova-wallet/substrate-sdk-ios.git", from: "5.8.0")
 ]
 ```
 

--- a/SubstrateSdk/Classes/Network/HTTPEngine+Protocol.swift
+++ b/SubstrateSdk/Classes/Network/HTTPEngine+Protocol.swift
@@ -5,6 +5,7 @@ extension HTTPEngine: JSONRPCEngine {
         _: String,
         params _: P?,
         unsubscribeMethod _: String,
+        options _: JSONRPCOptions,
         updateClosure _: @escaping (T) -> Void,
         failureClosure _: @escaping (Error, Bool) -> Void
     ) throws -> UInt16 where P: Encodable, T: Decodable {

--- a/SubstrateSdk/Classes/Network/JSONRPCEngine.swift
+++ b/SubstrateSdk/Classes/Network/JSONRPCEngine.swift
@@ -236,7 +236,6 @@ public extension JSONRPCEngine {
         )
     }
 
-    /// Backward-compatible overload: subscribes with default options (replayed on reconnect).
     func subscribe<P: Encodable, T: Decodable>(
         _ method: String,
         params: P?,
@@ -254,8 +253,6 @@ public extension JSONRPCEngine {
         )
     }
 
-    /// Default unsubscribe method, explicit options (e.g. `resendOnReconnect: false` to prevent
-    /// a non-idempotent subscription from being replayed on reconnect).
     func subscribe<P: Encodable, T: Decodable>(
         _ method: String,
         params: P?,

--- a/SubstrateSdk/Classes/Network/JSONRPCEngine.swift
+++ b/SubstrateSdk/Classes/Network/JSONRPCEngine.swift
@@ -192,6 +192,7 @@ public protocol JSONRPCEngine: AnyObject {
         _ method: String,
         params: P?,
         unsubscribeMethod: String,
+        options: JSONRPCOptions,
         updateClosure: @escaping (T) -> Void,
         failureClosure: @escaping (Error, Bool) -> Void
     )
@@ -235,6 +236,43 @@ public extension JSONRPCEngine {
         )
     }
 
+    /// Backward-compatible overload: subscribes with default options (replayed on reconnect).
+    func subscribe<P: Encodable, T: Decodable>(
+        _ method: String,
+        params: P?,
+        unsubscribeMethod: String,
+        updateClosure: @escaping (T) -> Void,
+        failureClosure: @escaping (Error, Bool) -> Void
+    ) throws -> UInt16 {
+        try subscribe(
+            method,
+            params: params,
+            unsubscribeMethod: unsubscribeMethod,
+            options: JSONRPCOptions(),
+            updateClosure: updateClosure,
+            failureClosure: failureClosure
+        )
+    }
+
+    /// Default unsubscribe method, explicit options (e.g. `resendOnReconnect: false` to prevent
+    /// a non-idempotent subscription from being replayed on reconnect).
+    func subscribe<P: Encodable, T: Decodable>(
+        _ method: String,
+        params: P?,
+        options: JSONRPCOptions,
+        updateClosure: @escaping (T) -> Void,
+        failureClosure: @escaping (Error, Bool) -> Void
+    ) throws -> UInt16 {
+        try subscribe(
+            method,
+            params: params,
+            unsubscribeMethod: RPCMethod.storageUnsubscribe,
+            options: options,
+            updateClosure: updateClosure,
+            failureClosure: failureClosure
+        )
+    }
+
     func subscribe<P: Encodable, T: Decodable>(
         _ method: String,
         params: P?,
@@ -245,6 +283,7 @@ public extension JSONRPCEngine {
             method,
             params: params,
             unsubscribeMethod: RPCMethod.storageUnsubscribe,
+            options: JSONRPCOptions(),
             updateClosure: updateClosure,
             failureClosure: failureClosure
         )

--- a/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
@@ -38,7 +38,7 @@ extension WebSocketEngine: WebSocketDelegate {
             let attempt = reconnectionAttempts[selectedURL] ?? 0
             scheduleReconnectionOrDisconnect(attempt + 1)
         case .connected:
-            let cancelledRequests = resetInProgress()
+            let cancelled = resetInProgress()
 
             pingScheduler.cancel()
 
@@ -46,7 +46,7 @@ extension WebSocketEngine: WebSocketDelegate {
             scheduleReconnectionOrDisconnect(1)
 
             notify(
-                requests: cancelledRequests,
+                cancelled: cancelled,
                 error: JSONRPCEngineError.clientCancelled
             )
         default:
@@ -63,7 +63,7 @@ extension WebSocketEngine: WebSocketDelegate {
 
         switch state {
         case .connected:
-            let cancelledRequests = resetInProgress()
+            let cancelled = resetInProgress()
 
             pingScheduler.cancel()
 
@@ -71,7 +71,7 @@ extension WebSocketEngine: WebSocketDelegate {
             startConnecting(0)
 
             notify(
-                requests: cancelledRequests,
+                cancelled: cancelled,
                 error: JSONRPCEngineError.unknownError
             )
         case .connecting:
@@ -119,14 +119,14 @@ extension WebSocketEngine: WebSocketDelegate {
             let attempt = reconnectionAttempts[selectedURL] ?? 0
             scheduleReconnectionOrDisconnect(attempt + 1)
         case .connected:
-            let cancelledRequests = resetInProgress()
+            let cancelled = resetInProgress()
 
             pingScheduler.cancel()
 
             scheduleReconnectionOrDisconnect(1)
 
             notify(
-                requests: cancelledRequests,
+                cancelled: cancelled,
                 error: JSONRPCEngineError.remoteCancelled
             )
         default:

--- a/SubstrateSdk/Classes/Network/WebSocketEngine+Protocol.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine+Protocol.swift
@@ -91,6 +91,7 @@ extension WebSocketEngine: JSONRPCEngine {
         _ method: String,
         params: P?,
         unsubscribeMethod: String,
+        options: JSONRPCOptions,
         updateClosure: @escaping (T) -> Void,
         failureClosure: @escaping (Error, Bool) -> Void
     ) throws -> UInt16 {
@@ -106,7 +107,7 @@ extension WebSocketEngine: JSONRPCEngine {
         let request = try prepareRequest(
             method: method,
             params: params,
-            options: JSONRPCOptions(resendOnReconnect: true),
+            options: options,
             completion: completion,
             preGeneratedRequestId: requestId
         )

--- a/SubstrateSdk/Classes/Network/WebSocketEngine.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine.swift
@@ -209,7 +209,7 @@ public final class WebSocketEngine {
         case .connected:
             state = .notConnected(url: selectedURL)
 
-            let cancelledRequests = resetInProgress()
+            let cancelled = resetInProgress()
 
             if force {
                 forceConnectionReset()
@@ -218,7 +218,7 @@ public final class WebSocketEngine {
             }
 
             notify(
-                requests: cancelledRequests,
+                cancelled: cancelled,
                 error: JSONRPCEngineError.clientCancelled
             )
 
@@ -336,7 +336,15 @@ extension WebSocketEngine {
         connection.delegate = self
     }
 
-    func resetInProgress() -> [JSONRPCRequest] {
+    /// In-flight requests and subscriptions cancelled by a disconnect (rather than replayed).
+    struct CancelledEntities {
+        let requests: [JSONRPCRequest]
+        let subscriptions: [JSONRPCSubscribing]
+    }
+
+    /// Clears the in-flight state, returning the requests and subscriptions that were cancelled
+    /// (rather than replayed) so the caller can `notify` them with the appropriate error.
+    func resetInProgress() -> CancelledEntities {
         // we can have batches decomposed by single requests
         let inProgressWithoutDuplicates = inProgressRequests.values.reduce(into: [JSONRPCRequestId: JSONRPCRequest]()) {
             $0[$1.requestId] = $1
@@ -353,30 +361,45 @@ extension WebSocketEngine {
         pendingRequests.append(contentsOf: idempotentRequests)
         inProgressRequests = [:]
 
-        rescheduleActiveSubscriptions()
+        let cancelledSubscriptions = resetActiveSubscriptions()
 
-        return notifiableRequests
+        return CancelledEntities(requests: notifiableRequests, subscriptions: cancelledSubscriptions)
     }
 
-    func rescheduleActiveSubscriptions() {
-        let activeSubscriptions = subscriptions.compactMap {
-            $1.remoteId != nil ? $1 : nil
+    /// Re-queues idempotent, already-acknowledged subscriptions to resubscribe after reconnect and
+    /// removes non-idempotent ones (which must not be replayed), returning them so the caller can
+    /// notify their subscribers that they won't be restored.
+    func resetActiveSubscriptions() -> [JSONRPCSubscribing] {
+        let allSubscriptions = Array(subscriptions.values)
+
+        let nonIdempotentSubscriptions = allSubscriptions.filter { !$0.requestOptions.resendOnReconnect }
+
+        for subscription in nonIdempotentSubscriptions {
+            subscriptions.removeValue(forKey: subscription.requestId)
         }
 
-        for subscription in activeSubscriptions {
+        // Idempotent, already-acknowledged subscriptions are re-queued to resubscribe after reconnect.
+        // Not-yet-acknowledged ones ride their in-flight (idempotent) subscribe request.
+        let resendableSubscriptions = allSubscriptions.filter {
+            $0.requestOptions.resendOnReconnect && $0.remoteId != nil
+        }
+
+        for subscription in resendableSubscriptions {
             subscription.remoteId = nil
         }
 
-        let subscriptionRequests: [JSONRPCRequest] = activeSubscriptions.enumerated().map {
+        let subscriptionRequests: [JSONRPCRequest] = resendableSubscriptions.map {
             JSONRPCRequest(
-                requestId: .single($1.requestId),
-                data: $1.requestData,
-                options: $1.requestOptions,
+                requestId: .single($0.requestId),
+                data: $0.requestData,
+                options: $0.requestOptions,
                 responseHandler: nil
             )
         }
 
         pendingRequests.append(contentsOf: subscriptionRequests)
+
+        return nonIdempotentSubscriptions
     }
 
     func process(data: Data) {
@@ -643,6 +666,16 @@ extension WebSocketEngine {
         }
     }
 
+    func notify(cancelled: CancelledEntities, error: Error) {
+        notify(requests: cancelled.requests, error: error)
+
+        cancelled.subscriptions.forEach { subscription in
+            completionQueue.async {
+                subscription.handle(error: error, unsubscribed: true)
+            }
+        }
+    }
+
     func notify(request: JSONRPCRequest, error: Error, identifier: UInt16) {
         completionQueue.async {
             request.responseHandler?.handle(error: error, for: identifier)
@@ -692,14 +725,14 @@ extension WebSocketEngine {
     }
 
     func resetRequestsAndSwitchNode() {
-        let cancelledRequests = resetInProgress()
+        let cancelled = resetInProgress()
 
         pingScheduler.cancel()
 
         let reconnectionAttempt = switchNode()
         startConnecting(reconnectionAttempt)
 
-        notify(requests: cancelledRequests, error: JSONRPCEngineError.unknownError)
+        notify(cancelled: cancelled, error: JSONRPCEngineError.unknownError)
     }
 
     func switchNode() -> Int {

--- a/SubstrateSdk/Classes/Network/WebSocketEngine.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine.swift
@@ -336,14 +336,11 @@ extension WebSocketEngine {
         connection.delegate = self
     }
 
-    /// In-flight requests and subscriptions cancelled by a disconnect (rather than replayed).
     struct CancelledEntities {
         let requests: [JSONRPCRequest]
         let subscriptions: [JSONRPCSubscribing]
     }
 
-    /// Clears the in-flight state, returning the requests and subscriptions that were cancelled
-    /// (rather than replayed) so the caller can `notify` them with the appropriate error.
     func resetInProgress() -> CancelledEntities {
         // we can have batches decomposed by single requests
         let inProgressWithoutDuplicates = inProgressRequests.values.reduce(into: [JSONRPCRequestId: JSONRPCRequest]()) {
@@ -366,9 +363,6 @@ extension WebSocketEngine {
         return CancelledEntities(requests: notifiableRequests, subscriptions: cancelledSubscriptions)
     }
 
-    /// Re-queues idempotent, already-acknowledged subscriptions to resubscribe after reconnect and
-    /// removes non-idempotent ones (which must not be replayed), returning them so the caller can
-    /// notify their subscribers that they won't be restored.
     func resetActiveSubscriptions() -> [JSONRPCSubscribing] {
         let allSubscriptions = Array(subscriptions.values)
 
@@ -378,8 +372,7 @@ extension WebSocketEngine {
             subscriptions.removeValue(forKey: subscription.requestId)
         }
 
-        // Idempotent, already-acknowledged subscriptions are re-queued to resubscribe after reconnect.
-        // Not-yet-acknowledged ones ride their in-flight (idempotent) subscribe request.
+        // remoteId != nil ⇒ acknowledged; not-yet-acked subs resubscribe via their in-flight request
         let resendableSubscriptions = allSubscriptions.filter {
             $0.requestOptions.resendOnReconnect && $0.remoteId != nil
         }

--- a/Tests/Helpers/Mocks/MockWebSocketConnectionFactory.swift
+++ b/Tests/Helpers/Mocks/MockWebSocketConnectionFactory.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Starscream
+import SubstrateSdk
+
+/// `WebSocketConnectionFactoryProtocol` that hands the SDK a **real** Starscream `WebSocket`
+/// backed by a `MockWebSocketTransport`. Every connection the SDK creates (initial connect,
+/// reconnect, node switch) is recorded so tests can inspect or drive the current one via
+/// `latest`.
+public final class MockWebSocketConnectionFactory: WebSocketConnectionFactoryProtocol {
+    public private(set) var transports: [MockWebSocketTransport] = []
+
+    /// The transport backing the SDK's current connection.
+    public var latest: MockWebSocketTransport {
+        guard let transport = transports.last else {
+            fatalError("No connection has been created yet")
+        }
+
+        return transport
+    }
+
+    public init() {}
+
+    public func createConnection(
+        for url: URL,
+        processingQueue: DispatchQueue,
+        connectionTimeout: TimeInterval
+    ) -> WebSocketConnectionProtocol {
+        let transport = MockWebSocketTransport()
+        transports.append(transport)
+
+        let request = URLRequest(url: url, timeoutInterval: connectionTimeout)
+        let socket = WebSocket(request: request, engine: transport)
+        socket.callbackQueue = processingQueue
+
+        return socket
+    }
+}

--- a/Tests/Helpers/Mocks/MockWebSocketEngineDelegate.swift
+++ b/Tests/Helpers/Mocks/MockWebSocketEngineDelegate.swift
@@ -1,0 +1,22 @@
+import Foundation
+import SubstrateSdk
+
+/// Records `WebSocketEngine` delegate callbacks for assertions.
+public final class MockWebSocketEngineDelegate: WebSocketEngineDelegate {
+    public private(set) var stateTransitions: [(from: WebSocketEngine.State, to: WebSocketEngine.State)] = []
+    public private(set) var switchedURLs: [URL] = []
+
+    public init() {}
+
+    public func webSocketDidChangeState(
+        _: AnyObject,
+        from oldState: WebSocketEngine.State,
+        to newState: WebSocketEngine.State
+    ) {
+        stateTransitions.append((oldState, newState))
+    }
+
+    public func webSocketDidSwitchURL(_: AnyObject, newUrl: URL) {
+        switchedURLs.append(newUrl)
+    }
+}

--- a/Tests/Helpers/Mocks/MockWebSocketTransport.swift
+++ b/Tests/Helpers/Mocks/MockWebSocketTransport.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Starscream
+
+/// Mock of Starscream's low-level `Engine` (the transport that backs a real `WebSocket`).
+///
+/// This is the *proper* seam for testing anything built on a Starscream `WebSocket`:
+/// a genuine `WebSocket` is constructed around this transport (see
+/// `MockWebSocketConnectionFactory`), so the code under test talks to the real
+/// `WebSocket` while this mock records outbound I/O and lets the test push inbound
+/// events as if they came off the wire.
+public final class MockWebSocketTransport: Engine {
+    public struct Frame: Equatable {
+        public let data: Data
+        public let opcode: FrameOpCode
+    }
+
+    /// The close code Starscream uses for a graceful "going away" disconnect.
+    public static let goingAwayCloseCode = CloseCode.goingAway.rawValue
+
+    // Set by the owning `WebSocket` in `connect()`; it's the real `WebSocket` instance.
+    private weak var delegate: EngineDelegate?
+
+    public private(set) var startCount = 0
+    public private(set) var forceStopCount = 0
+    public private(set) var stopCloseCodes: [UInt16] = []
+    public private(set) var sentFrames: [Frame] = []
+    public private(set) var sentStrings: [String] = []
+
+    public init() {}
+
+    /// JSON-RPC payloads the SDK wrote (text frames).
+    public var sentRequests: [Data] { sentFrames.filter { $0.opcode == .textFrame }.map(\.data) }
+    public var pingCount: Int { sentFrames.filter { $0.opcode == .ping }.count }
+    public var pongCount: Int { sentFrames.filter { $0.opcode == .pong }.count }
+
+    // MARK: Engine
+
+    public func register(delegate: EngineDelegate) { self.delegate = delegate }
+    public func start(request _: URLRequest) { startCount += 1 }
+    public func stop(closeCode: UInt16) { stopCloseCodes.append(closeCode) }
+    public func forceStop() { forceStopCount += 1 }
+
+    public func write(data: Data, opcode: FrameOpCode, completion: (() -> Void)?) {
+        sentFrames.append(Frame(data: data, opcode: opcode))
+        completion?()
+    }
+
+    public func write(string: String, completion: (() -> Void)?) {
+        sentStrings.append(string)
+        completion?()
+    }
+
+    // MARK: Driving inbound events
+
+    /// Push an event as if received from the network. The owning `WebSocket` forwards it
+    /// to its `WebSocketDelegate` on its `callbackQueue`, exactly as in production.
+    public func simulate(_ event: WebSocketEvent) { delegate?.didReceive(event: event) }
+
+    public func simulateConnected() { simulate(.connected([:])) }
+    public func simulateText(_ string: String) { simulate(.text(string)) }
+    public func simulateBinary(_ data: Data) { simulate(.binary(data)) }
+    public func simulateDisconnected(
+        reason: String = "closed",
+        code: UInt16 = MockWebSocketTransport.goingAwayCloseCode
+    ) { simulate(.disconnected(reason, code)) }
+    public func simulatePing(_ data: Data = Data()) { simulate(.ping(data)) }
+    public func simulateError(_ error: Error?) { simulate(.error(error)) }
+    public func simulateCancelled() { simulate(.cancelled) }
+}

--- a/Tests/Helpers/Mocks/StubReconnectionStrategy.swift
+++ b/Tests/Helpers/Mocks/StubReconnectionStrategy.swift
@@ -1,0 +1,16 @@
+import Foundation
+import SubstrateSdk
+
+/// Reconnection strategy returning a fixed delay (or `nil` to make the engine give up),
+/// so tests don't depend on wall-clock backoff timing.
+public struct StubReconnectionStrategy: ReconnectionStrategyProtocol {
+    public let delay: TimeInterval?
+
+    public init(delay: TimeInterval?) {
+        self.delay = delay
+    }
+
+    public func reconnectAfter(attempt _: Int) -> TimeInterval? {
+        delay
+    }
+}

--- a/Tests/Network/WebSocketEngineTests.swift
+++ b/Tests/Network/WebSocketEngineTests.swift
@@ -1,0 +1,344 @@
+import Testing
+import Foundation
+import TestHelpers
+@testable import SubstrateSdk
+
+@Suite("WebSocketEngine")
+struct WebSocketEngineTests {
+    static let url1 = URL(string: "wss://node1.example")!
+    static let url2 = URL(string: "wss://node2.example")!
+
+    /// Wires a `WebSocketEngine` to shared mocks. The engine runs on a single serial queue;
+    /// events pushed into the mock transport hop through the real `WebSocket` onto that queue,
+    /// and the engine re-dispatches completions onto it too, so `drain()` settles all of it
+    /// before assertions.
+    private final class Harness {
+        let engine: WebSocketEngine
+        let delegate = MockWebSocketEngineDelegate()
+        let factory = MockWebSocketConnectionFactory()
+        let queue = DispatchQueue(label: "test.ws.engine")
+
+        /// Transport backing the engine's current connection.
+        var transport: MockWebSocketTransport { factory.latest }
+
+        init(
+            urls: [URL] = [WebSocketEngineTests.url1],
+            autoconnect: Bool = true,
+            reconnectionStrategy: ReconnectionStrategyProtocol = StubReconnectionStrategy(delay: 1000),
+            customNodeSwitcher: JSONRPCNodeSwitching? = nil
+        ) {
+            engine = WebSocketEngine(
+                urls: urls,
+                connectionFactory: factory,
+                customNodeSwitcher: customNodeSwitcher,
+                reachabilityManager: nil,
+                reconnectionStrategy: reconnectionStrategy,
+                processingQueue: queue,
+                autoconnect: autoconnect,
+                pingInterval: 0,
+                name: "test"
+            )!
+            engine.delegate = delegate
+        }
+
+        func drain() {
+            // Event delivery adds one async hop (WebSocket → engine) and the engine adds
+            // another (engine → completion); a few passes over the serial queue settle both.
+            for _ in 0 ..< 4 { queue.sync {} }
+        }
+
+        func connect() {
+            transport.simulateConnected()
+            drain()
+        }
+
+        func receiveText(_ string: String) {
+            transport.simulateText(string)
+            drain()
+        }
+
+        func serverDisconnect() {
+            transport.simulateDisconnected()
+            drain()
+        }
+
+        func receivePing() {
+            transport.simulatePing()
+            drain()
+        }
+    }
+
+    private func resultResponse(id: UInt16, result: String) -> String {
+        #"{"jsonrpc":"2.0","result":\#(result),"id":\#(id)}"#
+    }
+
+    private func errorResponse(id: UInt16, code: Int, message: String) -> String {
+        #"{"jsonrpc":"2.0","error":{"code":\#(code),"message":"\#(message)"},"id":\#(id)}"#
+    }
+
+    // MARK: init & connect
+
+    @Test("returns nil when constructed with no urls")
+    func returnsNilForEmptyUrls() {
+        let engine = WebSocketEngine(urls: [], autoconnect: false)
+        #expect(engine == nil)
+    }
+
+    @Test("autoconnect opens the socket and enters connecting")
+    func autoconnectStartsConnecting() {
+        let harness = Harness(autoconnect: true)
+
+        #expect(harness.engine.state == .connecting(url: Self.url1))
+        #expect(harness.transport.startCount == 1)
+    }
+
+    @Test("does not connect when autoconnect is disabled")
+    func noConnectWhenAutoconnectDisabled() {
+        let harness = Harness(autoconnect: false)
+
+        #expect(harness.engine.state == .notConnected(url: nil))
+        #expect(harness.transport.startCount == 0)
+    }
+
+    @Test("reports connected state through the delegate on the connected event")
+    func connectedEventUpdatesStateAndDelegate() {
+        let harness = Harness(autoconnect: true)
+
+        harness.connect()
+
+        #expect(harness.engine.state == .connected(url: Self.url1))
+        #expect(harness.delegate.stateTransitions.last?.to == .connected(url: Self.url1))
+    }
+
+    // MARK: request queueing
+
+    @Test("queues requests while connecting and flushes them once connected")
+    func queuesRequestsUntilConnected() throws {
+        let harness = Harness(autoconnect: true)
+
+        _ = try harness.engine.callMethod(
+            "system_health",
+            params: [String](),
+            options: JSONRPCOptions()
+        ) { (_: Result<Int, Error>) in }
+
+        // still connecting → nothing written yet, request is pending
+        #expect(harness.transport.sentRequests.isEmpty)
+        #expect(harness.engine.pendingRequests.count == 1)
+
+        harness.connect()
+
+        #expect(harness.transport.sentRequests.count == 1)
+        #expect(harness.engine.pendingRequests.isEmpty)
+    }
+
+    @Test("writes immediately when a call is made while connected")
+    func writesImmediatelyWhenConnected() throws {
+        let harness = Harness(autoconnect: true)
+        harness.connect()
+
+        _ = try harness.engine.callMethod(
+            "system_health",
+            params: [String](),
+            options: JSONRPCOptions()
+        ) { (_: Result<Int, Error>) in }
+        harness.drain()
+
+        #expect(harness.transport.sentRequests.count == 1)
+    }
+
+    // MARK: responses
+
+    @Test("delivers a successful result to the caller completion")
+    func deliversSuccessResult() throws {
+        let harness = Harness(autoconnect: true)
+        harness.connect()
+
+        var received: Result<Int, Error>?
+        let id = try harness.engine.callMethod(
+            "system_health",
+            params: [String](),
+            options: JSONRPCOptions()
+        ) { (result: Result<Int, Error>) in received = result }
+
+        harness.receiveText(resultResponse(id: id, result: "42"))
+
+        #expect(try received?.get() == 42)
+        #expect(harness.engine.inProgressRequests.isEmpty)
+    }
+
+    @Test("delivers a JSON-RPC error to the caller completion")
+    func deliversErrorResult() throws {
+        let harness = Harness(autoconnect: true)
+        harness.connect()
+
+        var received: Result<Int, Error>?
+        let id = try harness.engine.callMethod(
+            "system_health",
+            params: [String](),
+            options: JSONRPCOptions()
+        ) { (result: Result<Int, Error>) in received = result }
+
+        harness.receiveText(errorResponse(id: id, code: 1010, message: "boom"))
+
+        guard case let .failure(error) = received else {
+            Issue.record("expected failure, got \(String(describing: received))")
+            return
+        }
+        #expect((error as? JSONRPCError)?.code == 1010)
+    }
+
+    // MARK: subscriptions
+
+    @Test("captures the remote id and routes updates to the subscriber")
+    func subscriptionCapturesRemoteIdAndDeliversUpdate() throws {
+        let harness = Harness(autoconnect: true)
+        harness.connect()
+
+        var updates: [String] = []
+        let localId = try harness.engine.subscribe(
+            "state_subscribeStorage",
+            params: [String](),
+            unsubscribeMethod: "state_unsubscribeStorage",
+            updateClosure: { (update: JSONRPCSubscriptionUpdate<String>) in
+                updates.append(update.params.result)
+            },
+            failureClosure: { _, _ in }
+        )
+
+        // node acknowledges the subscription with its remote id
+        harness.receiveText(resultResponse(id: localId, result: "\"REMOTE_1\""))
+        #expect(harness.engine.subscriptions[localId]?.remoteId == "REMOTE_1")
+
+        // an update addressed to that remote id reaches the closure
+        harness.receiveText(
+            #"{"jsonrpc":"2.0","method":"state_storage","params":{"subscription":"REMOTE_1","result":"0xdeadbeef"}}"#
+        )
+        #expect(updates == ["0xdeadbeef"])
+    }
+
+    @Test("cancelling a subscription sends an unsubscribe and drops the handler")
+    func cancelSubscriptionUnsubscribesAndRemoves() throws {
+        let harness = Harness(autoconnect: true)
+        harness.connect()
+
+        let localId = try harness.engine.subscribe(
+            "state_subscribeStorage",
+            params: [String](),
+            unsubscribeMethod: "state_unsubscribeStorage",
+            updateClosure: { (_: JSONRPCSubscriptionUpdate<String>) in },
+            failureClosure: { _, _ in }
+        )
+        harness.receiveText(resultResponse(id: localId, result: "\"REMOTE_1\""))
+
+        let requestsBefore = harness.transport.sentRequests.count
+        harness.engine.cancelForIdentifier(localId)
+        harness.drain()
+
+        #expect(harness.engine.subscriptions[localId] == nil)
+        // an unsubscribe request was written
+        #expect(harness.transport.sentRequests.count == requestsBefore + 1)
+    }
+
+    // MARK: reconnection
+
+    @Test("re-queues active subscriptions and re-sends them after reconnect")
+    func subscriptionSurvivesReconnect() throws {
+        let harness = Harness(autoconnect: true)
+        harness.connect()
+
+        let localId = try harness.engine.subscribe(
+            "state_subscribeStorage",
+            params: [String](),
+            unsubscribeMethod: "state_unsubscribeStorage",
+            updateClosure: { (_: JSONRPCSubscriptionUpdate<String>) in },
+            failureClosure: { _, _ in }
+        )
+        harness.receiveText(resultResponse(id: localId, result: "\"REMOTE_1\""))
+        let requestsAfterSubscribe = harness.transport.sentRequests.count
+
+        // socket drops while connected
+        harness.serverDisconnect()
+
+        #expect(harness.engine.state == .waitingReconnection(url: Self.url1))
+        // subscription is retained, remote id cleared, and re-queued for replay
+        #expect(harness.engine.subscriptions[localId] != nil)
+        #expect(harness.engine.subscriptions[localId]?.remoteId == nil)
+        #expect(harness.engine.pendingRequests.contains { $0.requestId.itemIds.contains(localId) })
+
+        // reconnect and confirm the subscribe request is re-sent
+        harness.engine.connectIfNeeded()
+        harness.drain()
+        harness.connect()
+
+        #expect(harness.transport.sentRequests.count > requestsAfterSubscribe)
+    }
+
+    @Test("fails pending requests when the reconnection strategy gives up")
+    func givingUpFailsPendingRequests() throws {
+        let harness = Harness(
+            autoconnect: true,
+            reconnectionStrategy: StubReconnectionStrategy(delay: nil)
+        )
+        harness.connect()
+
+        var received: Result<Int, Error>?
+        _ = try harness.engine.callMethod(
+            "system_health",
+            params: [String](),
+            options: JSONRPCOptions(resendOnReconnect: false)
+        ) { (result: Result<Int, Error>) in received = result }
+
+        harness.serverDisconnect()
+
+        #expect(harness.engine.state == .notConnected(url: Self.url1))
+        guard case .failure = received else {
+            Issue.record("expected the in-flight request to fail")
+            return
+        }
+    }
+
+    // MARK: node switching
+
+    @Test("switches to the next node when a switch-worthy error code arrives")
+    func switchesNodeOnInterceptedErrorCode() throws {
+        let switcher = JSONRRPCodeNodeSwitcher(codes: [1013])
+        let harness = Harness(urls: [Self.url1, Self.url2], customNodeSwitcher: switcher)
+        harness.connect()
+
+        let id = try harness.engine.callMethod(
+            "system_health",
+            params: [String](),
+            options: JSONRPCOptions()
+        ) { (_: Result<Int, Error>) in }
+
+        harness.receiveText(errorResponse(id: id, code: 1013, message: "overloaded"))
+
+        #expect(harness.engine.selectedURL == Self.url2)
+        #expect(harness.delegate.switchedURLs.contains(Self.url2))
+    }
+
+    // MARK: disconnect & ping
+
+    @Test("disconnectIfNeeded gracefully closes and returns to notConnected")
+    func disconnectIfNeededClosesSocket() {
+        let harness = Harness(autoconnect: true)
+        harness.connect()
+
+        harness.engine.disconnectIfNeeded()
+        harness.drain()
+
+        #expect(harness.engine.state == .notConnected(url: Self.url1))
+        #expect(harness.transport.stopCloseCodes.contains(MockWebSocketTransport.goingAwayCloseCode))
+    }
+
+    @Test("answers an inbound websocket ping with a pong while connected")
+    func respondsToInboundPingWithPong() {
+        let harness = Harness(autoconnect: true)
+        harness.connect()
+
+        harness.receivePing()
+
+        #expect(harness.transport.pongCount == 1)
+    }
+}

--- a/Tests/Network/WebSocketEngineTests.swift
+++ b/Tests/Network/WebSocketEngineTests.swift
@@ -274,6 +274,40 @@ struct WebSocketEngineTests {
         #expect(harness.transport.sentRequests.count > requestsAfterSubscribe)
     }
 
+    @Test("does not replay a non-idempotent subscription on reconnect")
+    func nonIdempotentSubscriptionCancelledOnReconnect() throws {
+        let harness = Harness(autoconnect: true)
+        harness.connect()
+
+        var failure: (error: Error, unsubscribed: Bool)?
+        let localId = try harness.engine.subscribe(
+            "author_submitAndWatchExtrinsic",
+            params: [String](),
+            unsubscribeMethod: "author_unwatchExtrinsic",
+            options: JSONRPCOptions(resendOnReconnect: false),
+            updateClosure: { (_: JSONRPCSubscriptionUpdate<String>) in },
+            failureClosure: { error, unsubscribed in failure = (error, unsubscribed) }
+        )
+        harness.receiveText(resultResponse(id: localId, result: "\"REMOTE_1\""))
+        #expect(harness.engine.subscriptions[localId]?.remoteId == "REMOTE_1")
+
+        let requestsAfterSubscribe = harness.transport.sentRequests.count
+
+        // socket drops while connected
+        harness.serverDisconnect()
+
+        // subscription is cancelled (not re-queued) and the subscriber is notified it ended
+        #expect(harness.engine.subscriptions[localId] == nil)
+        #expect(!harness.engine.pendingRequests.contains { $0.requestId.itemIds.contains(localId) })
+        #expect(failure?.unsubscribed == true)
+
+        // reconnecting must not resend it
+        harness.engine.connectIfNeeded()
+        harness.drain()
+        harness.connect()
+        #expect(harness.transport.sentRequests.count == requestsAfterSubscribe)
+    }
+
     @Test("fails pending requests when the reconnection strategy gives up")
     func givingUpFailsPendingRequests() throws {
         let harness = Harness(

--- a/Tests/Network/WebSocketEngineTests.swift
+++ b/Tests/Network/WebSocketEngineTests.swift
@@ -122,7 +122,6 @@ struct WebSocketEngineTests {
             options: JSONRPCOptions()
         ) { (_: Result<Int, Error>) in }
 
-        // still connecting → nothing written yet, request is pending
         #expect(harness.transport.sentRequests.isEmpty)
         #expect(harness.engine.pendingRequests.count == 1)
 
@@ -206,11 +205,9 @@ struct WebSocketEngineTests {
             failureClosure: { _, _ in }
         )
 
-        // node acknowledges the subscription with its remote id
         harness.receiveText(resultResponse(id: localId, result: "\"REMOTE_1\""))
         #expect(harness.engine.subscriptions[localId]?.remoteId == "REMOTE_1")
 
-        // an update addressed to that remote id reaches the closure
         harness.receiveText(
             #"{"jsonrpc":"2.0","method":"state_storage","params":{"subscription":"REMOTE_1","result":"0xdeadbeef"}}"#
         )
@@ -236,7 +233,6 @@ struct WebSocketEngineTests {
         harness.drain()
 
         #expect(harness.engine.subscriptions[localId] == nil)
-        // an unsubscribe request was written
         #expect(harness.transport.sentRequests.count == requestsBefore + 1)
     }
 
@@ -257,16 +253,13 @@ struct WebSocketEngineTests {
         harness.receiveText(resultResponse(id: localId, result: "\"REMOTE_1\""))
         let requestsAfterSubscribe = harness.transport.sentRequests.count
 
-        // socket drops while connected
         harness.serverDisconnect()
 
         #expect(harness.engine.state == .waitingReconnection(url: Self.url1))
-        // subscription is retained, remote id cleared, and re-queued for replay
         #expect(harness.engine.subscriptions[localId] != nil)
         #expect(harness.engine.subscriptions[localId]?.remoteId == nil)
         #expect(harness.engine.pendingRequests.contains { $0.requestId.itemIds.contains(localId) })
 
-        // reconnect and confirm the subscribe request is re-sent
         harness.engine.connectIfNeeded()
         harness.drain()
         harness.connect()
@@ -293,15 +286,12 @@ struct WebSocketEngineTests {
 
         let requestsAfterSubscribe = harness.transport.sentRequests.count
 
-        // socket drops while connected
         harness.serverDisconnect()
 
-        // subscription is cancelled (not re-queued) and the subscriber is notified it ended
         #expect(harness.engine.subscriptions[localId] == nil)
         #expect(!harness.engine.pendingRequests.contains { $0.requestId.itemIds.contains(localId) })
         #expect(failure?.unsubscribed == true)
 
-        // reconnecting must not resend it
         harness.engine.connectIfNeeded()
         harness.drain()
         harness.connect()


### PR DESCRIPTION
## CHECKLIST

**Follow the checklist to help make your PR easier to review. Check off items as you complete them.**

- [x] Did you review your own PR?

- [x] Provide a SUMMARY description for this PR below.

- [x] Provide a SOLUTION description for this PR below.

- [ ] Did you acknowledge all the feedback in this PR?


## SUMMARY

`WebSocketEngine` unconditionally replays every active subscription when the socket
reconnects (network change, node switch, dropped connection). That is correct for
idempotent subscriptions (e.g. storage subscriptions), but unsafe for non-idempotent
ones such as `author_submitAndWatchExtrinsic` — replaying them re-submits the
extrinsic. There was no way to opt a subscription out of reconnect replay, so callers
with non-idempotent subscriptions had no safe option.

## SOLUTION

Add a per-subscription `resendOnReconnect` option, mirroring the existing request-level
`JSONRPCOptions.resendOnReconnect`.

**Core change**
- `JSONRPCEngine.subscribe(...)` now takes `options: JSONRPCOptions`. The default stays
  `resendOnReconnect: true`, so behavior is unchanged unless explicitly opted out.
  Backward-compatible overloads (without `options`, with/without `unsubscribeMethod`)
  are provided, so existing call sites compile unchanged.
- On reconnect, `WebSocketEngine` splits active subscriptions by `resendOnReconnect`:
  - `true` (default) → re-queued to resubscribe, as before.
  - `false` → **not** replayed; the subscription is removed and its failure closure is
    invoked with `unsubscribed: true` and the disconnect error, so the subscriber knows
    it won't be restored.
- Reconnect reset path refactored: `resetInProgress()` returns a
  `CancelledEntities { requests, subscriptions }` value and the caller delivers both
  through a single `notify(cancelled:error:)`, keeping the disconnect error at the call site.
- `HTTPEngine.subscribe` signature updated to match (still throws `unsupportedMethod`).

Usage:
```swift
try engine.subscribe(
    "author_submitAndWatchExtrinsic", params: [extrinsic],
    unsubscribeMethod: "author_unwatchExtrinsic",
    options: JSONRPCOptions(resendOnReconnect: false),
    updateClosure: ..., failureClosure: ...
)
```

**Tests**
- New `WebSocketEngineTests` (Swift Testing, 16 cases) covering the engine end-to-end:
  connect/queue/flush, request completion + errors, subscription lifecycle, idempotent
  replay vs non-idempotent cancellation on reconnect, node switching, ping/pong.
- Reusable mocks under `Tests/Helpers/Mocks/` that mock Starscream's low-level `Engine`
  behind a **real** `WebSocket` — so the production `WebSocket` path is exercised with
  no network I/O. `Package.swift` wires `Starscream` into `TestHelpers` and points
  `NetworkTests` at `TestHelpers`.

**Also in this PR (tooling/docs, no runtime impact)**
- `AGENTS.md` / `CLAUDE.md` and `.claude/docs/` (WebSocket-engine spec, testing guide, index).
- README rewritten for SPM-only install; CocoaPods no longer supported. `.build/` added to `.gitignore`.

**Notes**
- Adding `options:` to the `subscribe` protocol requirement is a source-breaking change
  for custom `JSONRPCEngine` conformers (e.g. mocks) — appropriate for the `base/5.0`
  target. Callers using the convenience overloads are unaffected.
- Alternative considered: a dedicated subscription-options type. Rejected in favour of
  reusing `JSONRPCOptions` for symmetry with requests.

## SOLUTION SCREENSHOTS

N/A — library change, no UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
