### PR TITLE
Fix/option bool 5.0

### DIFF
--- a/SubstrateSdk/Classes/Scale/Encodable/ScaleBoolOption.swift
+++ b/SubstrateSdk/Classes/Scale/Encodable/ScaleBoolOption.swift
@@ -34,9 +34,9 @@ extension ScaleBoolOption: ScaleEncodable {
         switch self {
         case .none:
             scaleEncoder.appendRaw(data: Data([0]))
-        case .valueFalse:
-            scaleEncoder.appendRaw(data: Data([1]))
         case .valueTrue:
+            scaleEncoder.appendRaw(data: Data([1]))
+        case .valueFalse:
             scaleEncoder.appendRaw(data: Data([2]))
         }
     }
@@ -51,9 +51,9 @@ extension ScaleBoolOption: ScaleDecodable {
         case 0:
             self = .none
         case 1:
-            self = .valueFalse
-        case 2:
             self = .valueTrue
+        case 2:
+            self = .valueFalse
         default:
             throw ScaleOptionDecodingError.invalidPrefix
         }

--- a/Tests/Scale/ScaleBoolOptionTests.swift
+++ b/Tests/Scale/ScaleBoolOptionTests.swift
@@ -9,6 +9,26 @@ class ScaleBoolOptionTests: XCTestCase {
         }
     }
 
+    /// Canonical SCALE encoding for optional booleans:
+    /// None -> 0x00, Some(true) -> 0x01, Some(false) -> 0x02
+    func testEncodesToCanonicalWireFormat() throws {
+        try performEncodingTest(value: .none, expectedByte: 0)
+        try performEncodingTest(value: .valueTrue, expectedByte: 1)
+        try performEncodingTest(value: .valueFalse, expectedByte: 2)
+    }
+
+    func testDecodesFromCanonicalWireFormat() throws {
+        try performDecodingTest(byte: 0, expectedValue: .none)
+        try performDecodingTest(byte: 1, expectedValue: .valueTrue)
+        try performDecodingTest(byte: 2, expectedValue: .valueFalse)
+    }
+
+    func testDecodingInvalidByteThrows() throws {
+        let decoder = try ScaleDecoder(data: Data([3]))
+
+        XCTAssertThrowsError(try ScaleBoolOption(scaleDecoder: decoder))
+    }
+
     // MARK: Private
 
     private func performValueTest(_ expectedValue: ScaleBoolOption) throws {
@@ -20,5 +40,21 @@ class ScaleBoolOptionTests: XCTestCase {
         let value = try ScaleBoolOption(scaleDecoder: decoder)
 
         XCTAssertEqual(expectedValue, value)
+    }
+
+    private func performEncodingTest(value: ScaleBoolOption, expectedByte: UInt8) throws {
+        let encoder = ScaleEncoder()
+
+        try value.encode(scaleEncoder: encoder)
+
+        XCTAssertEqual(encoder.encode(), Data([expectedByte]))
+    }
+
+    private func performDecodingTest(byte: UInt8, expectedValue: ScaleBoolOption) throws {
+        let decoder = try ScaleDecoder(data: Data([byte]))
+
+        let value = try ScaleBoolOption(scaleDecoder: decoder)
+
+        XCTAssertEqual(value, expectedValue)
     }
 }


### PR DESCRIPTION
## CHECKLIST

**Follow the checklist to help make your PR easier to review. Check off items as you complete them.**

- [x] Did you review your own PR?

- [x] Provide a SUMMARY description for this PR below.

- [x] Provide a SOLUTION description for this PR below.

- [ ] Did you acknowledge all the feedback in this PR?


## SUMMARY

Current implementation of ScaleOptionBool was incorrect encoding indexes for true/false

## SOLUTION

- add tests to confirm the issue
- update indexes