### PR TITLE
Better LTE/WIFI handling

### DIFF
--- a/SubstrateSdk/Classes/Network/JSONRPCOperation.swift
+++ b/SubstrateSdk/Classes/Network/JSONRPCOperation.swift
@@ -49,18 +49,12 @@ public class JSONRPCOperation<P: Encodable, T: Decodable>: BaseOperation<T> {
             self.mutex.lock()
 
             guard self.pendingRequest != nil else {
+                self.mutex.unlock()
                 return
             }
 
             self.pendingRequest = nil
             self.clearScheduler()
-
-            if
-                case let .failure(error) = result,
-                let jsonRPCEngineError = error as? JSONRPCEngineError,
-                jsonRPCEngineError == .clientCancelled {
-                return
-            }
 
             self.mutex.unlock()
 

--- a/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
@@ -17,11 +17,17 @@ extension WebSocketEngine: WebSocketDelegate {
             handleDisconnectedEvent(reason: reason, code: code)
         case let .ping(data):
             handlePing(data: data)
+        case let .pong(data):
+            handlePong(data: data)
+        case let .viabilityChanged(isViable):
+            handleViabilityChanged(isViable)
+        case let .reconnectSuggested(isSuggested):
+            handleReconnectSuggested(isSuggested)
         case let .error(error):
             handleErrorEvent(error)
         case .cancelled:
             handleCancelled()
-        default:
+        @unknown default:
             logger?.warning("(\(chainName):\(selectedURL)) Unhandled event \(event)")
         }
 
@@ -40,7 +46,7 @@ extension WebSocketEngine: WebSocketDelegate {
         case .connected:
             let cancelled = resetInProgress()
 
-            pingScheduler.cancel()
+            stopHealthMonitoring()
 
             forceConnectionReset()
             scheduleReconnectionOrDisconnect(1)
@@ -65,7 +71,7 @@ extension WebSocketEngine: WebSocketDelegate {
         case .connected:
             let cancelled = resetInProgress()
 
-            pingScheduler.cancel()
+            stopHealthMonitoring()
 
             connection.disconnect()
             startConnecting(0)
@@ -104,6 +110,10 @@ extension WebSocketEngine: WebSocketDelegate {
     private func handleConnectedEvent() {
         logger?.debug("(\(chainName):\(selectedURL)) connection established")
 
+        cancelPongTimeout()
+        updatePathViability(true)
+        clearBetterPathReconnect()
+
         updateReconnectionAttempts(0, for: selectedURL)
         changeState(.connected(url: selectedURL))
         sendAllPendingRequests()
@@ -121,7 +131,7 @@ extension WebSocketEngine: WebSocketDelegate {
         case .connected:
             let cancelled = resetInProgress()
 
-            pingScheduler.cancel()
+            stopHealthMonitoring()
 
             scheduleReconnectionOrDisconnect(1)
 
@@ -143,6 +153,40 @@ extension WebSocketEngine: WebSocketDelegate {
         default:
             logger?.warning("(\(chainName):\(selectedURL)) Ping data received but not connected")
         }
+    }
+
+    private func handlePong(data: Data?) {
+        logger?.debug("(\(chainName):\(selectedURL)) Did receive pong: \((data ?? Data()).toHex())")
+
+        cancelPongTimeout()
+    }
+
+    private func handleViabilityChanged(_ isViable: Bool) {
+        logger?.debug("(\(chainName):\(selectedURL)) Connection viability changed: \(isViable)")
+
+        updatePathViability(isViable)
+    }
+
+    private func handleReconnectSuggested(_ isSuggested: Bool) {
+        guard case .connected = state else {
+            return
+        }
+
+        guard isSuggested else {
+            clearBetterPathReconnect()
+            return
+        }
+
+        guard !hasNonResendableInFlight else {
+            logger?.debug("(\(chainName):\(selectedURL)) Better network path available, waiting for in-flight requests")
+
+            scheduleBetterPathReconnect()
+            return
+        }
+
+        logger?.debug("(\(chainName):\(selectedURL)) Better network path available, reconnecting")
+
+        restartConnection()
     }
 }
 
@@ -167,6 +211,10 @@ extension WebSocketEngine: SchedulerDelegate {
 
         if scheduler === pingScheduler {
             handlePing(scheduler: scheduler)
+        } else if scheduler === pongTimeoutScheduler {
+            handlePongTimeout()
+        } else if scheduler === viabilityTimeoutScheduler {
+            handleViabilityTimeout()
         } else {
             handleReconnection(scheduler: scheduler)
         }
@@ -185,9 +233,30 @@ extension WebSocketEngine: SchedulerDelegate {
 
     private func handlePing(scheduler _: SchedulerProtocol) {
         schedulePingIfNeeded()
+        schedulePongTimeoutIfNeeded()
 
         connection.callbackQueue.async {
             self.sendPing()
         }
+    }
+
+    private func handlePongTimeout() {
+        guard case .connected = state, awaitingPong else {
+            return
+        }
+
+        logger?.warning("(\(chainName):\(selectedURL)) No pong received in \(pongTimeout)s, restarting connection")
+
+        restartConnection()
+    }
+
+    private func handleViabilityTimeout() {
+        guard case .connected = state, !isPathViable else {
+            return
+        }
+
+        logger?.warning("(\(chainName):\(selectedURL)) Connection is no longer viable, restarting")
+
+        restartConnection()
     }
 }

--- a/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
@@ -95,11 +95,16 @@ extension WebSocketEngine: WebSocketDelegate {
             logger?.debug("(\(chainName):\(selectedURL)) Did receive data: \(decodedString.prefix(1024))")
         }
 
+        cancelPongTimeout()
+
         process(data: data)
     }
 
     private func handleTextEvent(string: String) {
         logger?.debug("(\(chainName):\(selectedURL)) Did receive text: \(string.prefix(1024))")
+
+        cancelPongTimeout()
+
         if let data = string.data(using: .utf8) {
             process(data: data)
         } else {

--- a/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
@@ -238,7 +238,6 @@ extension WebSocketEngine: SchedulerDelegate {
 
     private func handlePing(scheduler _: SchedulerProtocol) {
         schedulePingIfNeeded()
-        schedulePongTimeoutIfNeeded()
 
         connection.callbackQueue.async {
             self.sendPing()

--- a/SubstrateSdk/Classes/Network/WebSocketEngine+Protocol.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine+Protocol.swift
@@ -135,6 +135,8 @@ extension WebSocketEngine: JSONRPCEngine {
             cancelRequestForLocalId(identifier)
         }
 
+        completeBetterPathReconnectIfNeeded()
+
         mutex.unlock()
     }
 }

--- a/SubstrateSdk/Classes/Network/WebSocketEngine.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine.swift
@@ -44,6 +44,8 @@ public final class WebSocketEngine {
     public let processingQueue: DispatchQueue
     public let pingInterval: TimeInterval
     public let connectionTimeout: TimeInterval
+    public let pongTimeout: TimeInterval
+    public let viabilityTimeout: TimeInterval
 
     public private(set) var state: State = .notConnected(url: nil) {
         didSet {
@@ -84,6 +86,16 @@ public final class WebSocketEngine {
         return scheduler
     }()
 
+    private(set) lazy var pongTimeoutScheduler: SchedulerProtocol = {
+        let scheduler = Scheduler(with: self, callbackQueue: processingQueue)
+        return scheduler
+    }()
+
+    private(set) lazy var viabilityTimeoutScheduler: SchedulerProtocol = {
+        let scheduler = Scheduler(with: self, callbackQueue: processingQueue)
+        return scheduler
+    }()
+
     public var chainName: String { name ?? "unknown" }
 
     private(set) var pendingRequests: [JSONRPCRequest] = []
@@ -93,6 +105,9 @@ public final class WebSocketEngine {
     private(set) var pendingSubscriptionResponses: [String: [Data]] = [:]
     private(set) var selectedURLIndex: Int
     private(set) var reconnectionAttempts: [URL: Int] = [:]
+    private(set) var pendingBetterPathReconnect: Bool = false
+    private(set) var awaitingPong: Bool = false
+    private(set) var isPathViable: Bool = true
     public var selectedURL: URL { urls[selectedURLIndex] }
 
     public weak var delegate: WebSocketEngineDelegate?
@@ -109,6 +124,8 @@ public final class WebSocketEngine {
         autoconnect: Bool = true,
         connectionTimeout: TimeInterval = 10.0,
         pingInterval: TimeInterval = 30,
+        pongTimeout: TimeInterval = 10,
+        viabilityTimeout: TimeInterval = 2,
         name: String? = nil,
         logger: SDKLoggerProtocol? = nil
     ) {
@@ -125,6 +142,8 @@ public final class WebSocketEngine {
         self.processingQueue = processingQueue ?? JSONRPCEngineShared.processingQueue
         self.pingInterval = pingInterval
         self.connectionTimeout = connectionTimeout
+        self.pongTimeout = pongTimeout
+        self.viabilityTimeout = viabilityTimeout
         selectedURLIndex = 0
 
         guard let url = urls.first else {
@@ -222,7 +241,7 @@ public final class WebSocketEngine {
                 error: JSONRPCEngineError.clientCancelled
             )
 
-            pingScheduler.cancel()
+            stopHealthMonitoring()
 
             logger?.debug("(\(chainName):\(selectedURL)) Did start disconnect from socket")
         case .connecting:
@@ -443,6 +462,8 @@ extension WebSocketEngine {
                 logger?.error("(\(chainName):\(selectedURL)) Can't parse data")
             }
         }
+
+        completeBetterPathReconnectIfNeeded()
     }
 
     @discardableResult
@@ -720,7 +741,7 @@ extension WebSocketEngine {
     func resetRequestsAndSwitchNode() {
         let cancelled = resetInProgress()
 
-        pingScheduler.cancel()
+        stopHealthMonitoring()
 
         let reconnectionAttempt = switchNode()
         startConnecting(reconnectionAttempt)
@@ -765,6 +786,75 @@ extension WebSocketEngine {
         pingScheduler.notifyAfter(pingInterval)
     }
 
+    func schedulePongTimeoutIfNeeded() {
+        guard pongTimeout > 0.0, case .connected = state, !awaitingPong else {
+            return
+        }
+
+        awaitingPong = true
+        pongTimeoutScheduler.notifyAfter(pongTimeout)
+    }
+
+    func cancelPongTimeout() {
+        awaitingPong = false
+        pongTimeoutScheduler.cancel()
+    }
+
+    func updatePathViability(_ isViable: Bool) {
+        isPathViable = isViable
+
+        if isViable {
+            viabilityTimeoutScheduler.cancel()
+        } else if viabilityTimeout > 0.0, case .connected = state {
+            viabilityTimeoutScheduler.notifyAfter(viabilityTimeout)
+        }
+    }
+
+    func stopHealthMonitoring() {
+        pingScheduler.cancel()
+        cancelPongTimeout()
+
+        isPathViable = true
+        viabilityTimeoutScheduler.cancel()
+    }
+
+    func restartConnection() {
+        clearBetterPathReconnect()
+
+        let cancelled = resetInProgress()
+
+        stopHealthMonitoring()
+        forceConnectionReset()
+        startConnecting(0)
+
+        notify(cancelled: cancelled, error: JSONRPCEngineError.clientCancelled)
+    }
+
+    var hasNonResendableInFlight: Bool {
+        inProgressRequests.contains { !$0.value.options.resendOnReconnect } ||
+            subscriptions.contains { !$0.value.requestOptions.resendOnReconnect }
+    }
+
+    func scheduleBetterPathReconnect() {
+        pendingBetterPathReconnect = true
+    }
+
+    func clearBetterPathReconnect() {
+        pendingBetterPathReconnect = false
+    }
+
+    func completeBetterPathReconnectIfNeeded() {
+        guard pendingBetterPathReconnect, case .connected = state, !hasNonResendableInFlight else {
+            return
+        }
+
+        pendingBetterPathReconnect = false
+
+        logger?.debug("(\(chainName):\(selectedURL)) In-flight requests finished, reconnecting to better network path")
+
+        restartConnection()
+    }
+
     func sendPing() {
         guard case .connected = state else {
             logger?.warning("(\(chainName):\(selectedURL)) Tried to send ping but not connected")
@@ -781,6 +871,10 @@ extension WebSocketEngine {
                 sendWebsocketPing()
             }
         } catch {
+            mutex.lock()
+            cancelPongTimeout()
+            mutex.unlock()
+
             logger?.error("(\(chainName)) Did receive ping error: \(error)")
         }
     }
@@ -805,6 +899,10 @@ extension WebSocketEngine {
     }
 
     func handlePing(result: Result<SubstrateHealthResult, Error>) {
+        mutex.lock()
+        cancelPongTimeout()
+        mutex.unlock()
+
         switch result {
         case let .success(health):
             if health.isSyncing {

--- a/SubstrateSdk/Classes/Network/WebSocketEngine.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine.swift
@@ -901,10 +901,6 @@ extension WebSocketEngine {
     }
 
     func handlePing(result: Result<SubstrateHealthResult, Error>) {
-        mutex.lock()
-        cancelPongTimeout()
-        mutex.unlock()
-
         switch result {
         case let .success(health):
             if health.isSyncing {

--- a/SubstrateSdk/Classes/Network/WebSocketEngine.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine.swift
@@ -171,6 +171,8 @@ public final class WebSocketEngine {
 
         reconnectionScheduler.cancel()
         pingScheduler.cancel()
+        pongTimeoutScheduler.cancel()
+        viabilityTimeoutScheduler.cancel()
     }
 
     public func changeUrls(_ newUrls: [URL]) {
@@ -827,7 +829,7 @@ extension WebSocketEngine {
         forceConnectionReset()
         startConnecting(0)
 
-        notify(cancelled: cancelled, error: JSONRPCEngineError.clientCancelled)
+        notify(cancelled: cancelled, error: JSONRPCEngineError.remoteCancelled)
     }
 
     var hasNonResendableInFlight: Bool {

--- a/SubstrateSdk/Classes/Network/WebSocketEngine.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine.swift
@@ -858,7 +858,20 @@ extension WebSocketEngine {
     }
 
     func sendPing() {
-        guard case .connected = state else {
+        mutex.lock()
+
+        let canSendPing: Bool
+
+        if case .connected = state {
+            schedulePongTimeoutIfNeeded()
+            canSendPing = true
+        } else {
+            canSendPing = false
+        }
+
+        mutex.unlock()
+
+        guard canSendPing else {
             logger?.warning("(\(chainName):\(selectedURL)) Tried to send ping but not connected")
             return
         }

--- a/Tests/Helpers/Mocks/MockWebSocketConnectionFactory.swift
+++ b/Tests/Helpers/Mocks/MockWebSocketConnectionFactory.swift
@@ -18,6 +18,8 @@ public final class MockWebSocketConnectionFactory: WebSocketConnectionFactoryPro
         return transport
     }
 
+    public var onCreateConnection: ((MockWebSocketTransport) -> Void)?
+
     public init() {}
 
     public func createConnection(
@@ -27,6 +29,7 @@ public final class MockWebSocketConnectionFactory: WebSocketConnectionFactoryPro
     ) -> WebSocketConnectionProtocol {
         let transport = MockWebSocketTransport()
         transports.append(transport)
+        onCreateConnection?(transport)
 
         let request = URLRequest(url: url, timeoutInterval: connectionTimeout)
         let socket = WebSocket(request: request, engine: transport)

--- a/Tests/Helpers/Mocks/MockWebSocketConnectionFactory.swift
+++ b/Tests/Helpers/Mocks/MockWebSocketConnectionFactory.swift
@@ -18,8 +18,6 @@ public final class MockWebSocketConnectionFactory: WebSocketConnectionFactoryPro
         return transport
     }
 
-    public var onCreateConnection: ((MockWebSocketTransport) -> Void)?
-
     public init() {}
 
     public func createConnection(
@@ -29,7 +27,6 @@ public final class MockWebSocketConnectionFactory: WebSocketConnectionFactoryPro
     ) -> WebSocketConnectionProtocol {
         let transport = MockWebSocketTransport()
         transports.append(transport)
-        onCreateConnection?(transport)
 
         let request = URLRequest(url: url, timeoutInterval: connectionTimeout)
         let socket = WebSocket(request: request, engine: transport)

--- a/Tests/Helpers/Mocks/MockWebSocketTransport.swift
+++ b/Tests/Helpers/Mocks/MockWebSocketTransport.swift
@@ -40,9 +40,13 @@ public final class MockWebSocketTransport: Engine {
     public func stop(closeCode: UInt16) { stopCloseCodes.append(closeCode) }
     public func forceStop() { forceStopCount += 1 }
 
+    public var onFrame: ((Frame) -> Void)?
+
     public func write(data: Data, opcode: FrameOpCode, completion: (() -> Void)?) {
-        sentFrames.append(Frame(data: data, opcode: opcode))
+        let frame = Frame(data: data, opcode: opcode)
+        sentFrames.append(frame)
         completion?()
+        onFrame?(frame)
     }
 
     public func write(string: String, completion: (() -> Void)?) {

--- a/Tests/Network/WebSocketEngineReconnectTests.swift
+++ b/Tests/Network/WebSocketEngineReconnectTests.swift
@@ -182,6 +182,27 @@ struct WebSocketEngineReconnectTests {
         #expect(harness.factory.transports.count == 2)
     }
 
+    @Test("inbound traffic keeps the connection alive without pongs")
+    func inboundTrafficSatisfiesPongTimeout() async {
+        let harness = Harness(pingInterval: 0.1, pongTimeout: 0.25)
+
+        let connection = harness.transport
+        connection.onFrame = { [weak connection] frame in
+            if frame.opcode == .ping {
+                connection?.simulateText("{\"jsonrpc\":\"2.0\",\"method\":\"noop\",\"params\":{}}")
+            }
+        }
+
+        harness.connect()
+
+        let didReconnect = await harness.reconnectHappened(within: 1)
+        #expect(!didReconnect)
+
+        harness.drain()
+        #expect(harness.factory.transports.count == 1)
+        #expect(harness.engine.state == .connected(url: Self.url))
+    }
+
     @Test("answered pings keep the connection alive")
     func pongReceptionKeepsConnectionAlive() async {
         let harness = Harness(pingInterval: 0.1, pongTimeout: 0.3)

--- a/Tests/Network/WebSocketEngineReconnectTests.swift
+++ b/Tests/Network/WebSocketEngineReconnectTests.swift
@@ -1,0 +1,285 @@
+import Testing
+import Foundation
+import TestHelpers
+@testable import SubstrateSdk
+
+@Suite("WebSocketEngine reconnect on network path changes")
+struct WebSocketEngineReconnectTests {
+    static let url = URL(string: "wss://node1.example")!
+
+    @Test("viability loss restarts the connection after the grace period")
+    func viabilityLossTriggersReconnect() async {
+        let harness = Harness()
+
+        harness.connect()
+        harness.transport.simulate(.viabilityChanged(false))
+
+        let didReconnect = await harness.reconnectHappened()
+        #expect(didReconnect)
+
+        harness.drain()
+        #expect(harness.factory.transports.count == 2)
+        #expect(harness.factory.latest.startCount == 1)
+    }
+
+    @Test("viability recovery within the grace period keeps the connection")
+    func viabilityRecoveryKeepsConnection() async {
+        let harness = Harness()
+
+        harness.connect()
+        harness.transport.simulate(.viabilityChanged(false))
+        harness.transport.simulate(.viabilityChanged(true))
+
+        let didReconnect = await harness.reconnectHappened(within: 0.5)
+        #expect(!didReconnect)
+
+        harness.drain()
+        #expect(harness.factory.transports.count == 1)
+        #expect(harness.engine.state == .connected(url: Self.url))
+    }
+
+    @Test("better path suggestion reconnects immediately when idle")
+    func betterPathTriggersImmediateReconnect() async {
+        let harness = Harness()
+
+        harness.connect()
+        harness.transport.simulate(.reconnectSuggested(true))
+
+        let didReconnect = await harness.reconnectHappened()
+        #expect(didReconnect)
+
+        harness.drain()
+        #expect(harness.factory.transports.count == 2)
+        #expect(harness.factory.latest.startCount == 1)
+    }
+
+    @Test("better path waits for a non-resendable in-flight request")
+    func betterPathWaitsForInFlight() async throws {
+        let harness = Harness()
+
+        harness.connect()
+
+        let requestId = try harness.submitNonResendableRequest()
+        harness.drain()
+
+        harness.transport.simulate(.reconnectSuggested(true))
+
+        let reconnectedEarly = await harness.reconnectHappened(within: 0.5)
+        #expect(!reconnectedEarly)
+
+        harness.drain()
+        #expect(harness.engine.pendingBetterPathReconnect)
+
+        harness.respond(to: requestId)
+
+        let didReconnect = await harness.reconnectHappened()
+        #expect(didReconnect)
+
+        harness.drain()
+        #expect(!harness.engine.pendingBetterPathReconnect)
+        #expect(harness.factory.transports.count == 2)
+    }
+
+    @Test("withdrawn better path suggestion cancels the deferred reconnect")
+    func withdrawnBetterPathCancelsDeferredReconnect() async throws {
+        let harness = Harness()
+
+        harness.connect()
+
+        let requestId = try harness.submitNonResendableRequest()
+        harness.drain()
+
+        harness.transport.simulate(.reconnectSuggested(true))
+        harness.transport.simulate(.reconnectSuggested(false))
+
+        harness.respond(to: requestId)
+
+        let didReconnect = await harness.reconnectHappened(within: 0.5)
+        #expect(!didReconnect)
+
+        harness.drain()
+        #expect(harness.factory.transports.count == 1)
+        #expect(harness.engine.state == .connected(url: Self.url))
+    }
+
+    @Test("dead path restart drops the deferred better path reconnect")
+    func deadPathRestartDropsDeferredReconnect() async throws {
+        let harness = Harness()
+
+        harness.connect()
+
+        try harness.submitNonResendableRequest()
+        harness.drain()
+
+        harness.transport.simulate(.reconnectSuggested(true))
+        harness.transport.simulate(.viabilityChanged(false))
+
+        let didReconnect = await harness.reconnectHappened()
+        #expect(didReconnect)
+
+        harness.drain()
+        harness.connect()
+
+        let requestId = try harness.submitNonResendableRequest()
+        harness.drain()
+        harness.respond(to: requestId)
+
+        let reconnectedAgain = await harness.transportCountReached(3, within: 0.5)
+        #expect(!reconnectedAgain)
+
+        harness.drain()
+        #expect(harness.engine.state == .connected(url: Self.url))
+    }
+
+    @Test("late pong timeout after pong received does not restart the connection")
+    func latePongTimeoutAfterPongIsIgnored() async {
+        let harness = Harness(pongTimeout: 5)
+
+        harness.connect()
+
+        harness.engine.didTrigger(scheduler: harness.engine.pingScheduler)
+        harness.drain()
+        #expect(harness.engine.awaitingPong)
+
+        harness.transport.simulate(.pong(nil))
+        harness.drain()
+
+        harness.engine.didTrigger(scheduler: harness.engine.pongTimeoutScheduler)
+        harness.drain()
+
+        #expect(harness.factory.transports.count == 1)
+        #expect(harness.engine.state == .connected(url: Self.url))
+    }
+
+    @Test("late viability timeout after recovery does not restart the connection")
+    func lateViabilityTimeoutAfterRecoveryIsIgnored() async {
+        let harness = Harness(viabilityTimeout: 5)
+
+        harness.connect()
+
+        harness.transport.simulate(.viabilityChanged(false))
+        harness.transport.simulate(.viabilityChanged(true))
+        harness.drain()
+
+        harness.engine.didTrigger(scheduler: harness.engine.viabilityTimeoutScheduler)
+        harness.drain()
+
+        #expect(harness.factory.transports.count == 1)
+        #expect(harness.engine.state == .connected(url: Self.url))
+    }
+
+    @Test("missing pong restarts the connection")
+    func missingPongTriggersReconnect() async {
+        let harness = Harness(pingInterval: 0.3, pongTimeout: 0.1)
+
+        harness.connect()
+
+        let didReconnect = await harness.reconnectHappened()
+        #expect(didReconnect)
+
+        harness.drain()
+        #expect(harness.factory.transports.first?.pingCount ?? 0 >= 1)
+        #expect(harness.factory.transports.count == 2)
+    }
+
+    @Test("answered pings keep the connection alive")
+    func pongReceptionKeepsConnectionAlive() async {
+        let harness = Harness(pingInterval: 0.1, pongTimeout: 0.3)
+
+        harness.connect()
+
+        let connection = harness.transport
+        connection.onFrame = { [weak connection] frame in
+            if frame.opcode == .ping {
+                connection?.simulate(.pong(nil))
+            }
+        }
+
+        let didReconnect = await harness.reconnectHappened(within: 1)
+        #expect(!didReconnect)
+
+        harness.drain()
+        #expect(connection.pingCount >= 2)
+        #expect(harness.factory.transports.count == 1)
+        #expect(harness.engine.state == .connected(url: Self.url))
+    }
+}
+
+
+/// A reconnect always makes the engine request a fresh transport from the factory,
+/// so tests detect it by polling the number of created transports.
+private final class Harness {
+    let engine: WebSocketEngine
+    let delegate = MockWebSocketEngineDelegate()
+    let factory = MockWebSocketConnectionFactory()
+    let queue = DispatchQueue(label: "test.ws.reconnect")
+
+    var transport: MockWebSocketTransport { factory.latest }
+
+    init(
+        pingInterval: TimeInterval = 0,
+        pongTimeout: TimeInterval = 0.1,
+        viabilityTimeout: TimeInterval = 0.1
+    ) {
+        engine = WebSocketEngine(
+            urls: [WebSocketEngineReconnectTests.url],
+            connectionFactory: factory,
+            reachabilityManager: nil,
+            reconnectionStrategy: StubReconnectionStrategy(delay: 1000),
+            processingQueue: queue,
+            autoconnect: true,
+            pingInterval: pingInterval,
+            pongTimeout: pongTimeout,
+            viabilityTimeout: viabilityTimeout,
+            name: "test"
+        )!
+        engine.delegate = delegate
+    }
+
+    func drain() {
+        for _ in 0 ..< 4 { queue.sync {} }
+    }
+
+    func connect() {
+        transport.simulateConnected()
+        drain()
+    }
+
+    @discardableResult
+    func submitNonResendableRequest() throws -> UInt16 {
+        try engine.callMethod(
+            "extrinsic",
+            params: ["0x00"],
+            options: JSONRPCOptions(resendOnReconnect: false)
+        ) { (_: Result<String, Error>) in }
+    }
+
+    func respond(to requestId: UInt16) {
+        transport.simulateText("{\"jsonrpc\":\"2.0\",\"result\":\"0x00\",\"id\":\(requestId)}")
+        drain()
+    }
+
+    func transportCount() -> Int {
+        var count = 0
+        queue.sync { count = factory.transports.count }
+        return count
+    }
+
+    func transportCountReached(_ expected: Int, within timeout: TimeInterval = 2) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            if transportCount() >= expected {
+                return true
+            }
+
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        return transportCount() >= expected
+    }
+
+    func reconnectHappened(within timeout: TimeInterval = 2) async -> Bool {
+        await transportCountReached(2, within: timeout)
+    }
+}

--- a/Tests/Network/WebSocketEngineReconnectTests.swift
+++ b/Tests/Network/WebSocketEngineReconnectTests.swift
@@ -186,14 +186,14 @@ struct WebSocketEngineReconnectTests {
     func pongReceptionKeepsConnectionAlive() async {
         let harness = Harness(pingInterval: 0.1, pongTimeout: 0.3)
 
-        harness.connect()
-
         let connection = harness.transport
         connection.onFrame = { [weak connection] frame in
             if frame.opcode == .ping {
                 connection?.simulate(.pong(nil))
             }
         }
+
+        harness.connect()
 
         let didReconnect = await harness.reconnectHappened(within: 1)
         #expect(!didReconnect)

--- a/Tests/Network/WebSocketEngineReconnectTests.swift
+++ b/Tests/Network/WebSocketEngineReconnectTests.swift
@@ -22,39 +22,36 @@ struct WebSocketEngineReconnectTests {
         #expect(harness.factory.latest.startCount == 1)
     }
 
-    @Test("viability recovery within the grace period keeps the connection")
-    func viabilityRecoveryKeepsConnection() async {
-        let harness = Harness()
+    @Test("viability recovery keeps the connection even if the grace timer fires late")
+    func viabilityRecoveryKeepsConnection() {
+        let harness = Harness(viabilityTimeout: 60)
 
         harness.connect()
         harness.transport.simulate(.viabilityChanged(false))
         harness.transport.simulate(.viabilityChanged(true))
-
-        let didReconnect = await harness.reconnectHappened(within: 0.5)
-        #expect(!didReconnect)
-
         harness.drain()
+
+        harness.engine.didTrigger(scheduler: harness.engine.viabilityTimeoutScheduler)
+        harness.drain()
+
         #expect(harness.factory.transports.count == 1)
         #expect(harness.engine.state == .connected(url: Self.url))
     }
 
     @Test("better path suggestion reconnects immediately when idle")
-    func betterPathTriggersImmediateReconnect() async {
+    func betterPathTriggersImmediateReconnect() {
         let harness = Harness()
 
         harness.connect()
         harness.transport.simulate(.reconnectSuggested(true))
-
-        let didReconnect = await harness.reconnectHappened()
-        #expect(didReconnect)
-
         harness.drain()
+
         #expect(harness.factory.transports.count == 2)
         #expect(harness.factory.latest.startCount == 1)
     }
 
     @Test("better path waits for a non-resendable in-flight request")
-    func betterPathWaitsForInFlight() async throws {
+    func betterPathWaitsForInFlight() throws {
         let harness = Harness()
 
         harness.connect()
@@ -63,25 +60,19 @@ struct WebSocketEngineReconnectTests {
         harness.drain()
 
         harness.transport.simulate(.reconnectSuggested(true))
-
-        let reconnectedEarly = await harness.reconnectHappened(within: 0.5)
-        #expect(!reconnectedEarly)
-
         harness.drain()
+
+        #expect(harness.factory.transports.count == 1)
         #expect(harness.engine.pendingBetterPathReconnect)
 
         harness.respond(to: requestId)
 
-        let didReconnect = await harness.reconnectHappened()
-        #expect(didReconnect)
-
-        harness.drain()
-        #expect(!harness.engine.pendingBetterPathReconnect)
         #expect(harness.factory.transports.count == 2)
+        #expect(!harness.engine.pendingBetterPathReconnect)
     }
 
     @Test("withdrawn better path suggestion cancels the deferred reconnect")
-    func withdrawnBetterPathCancelsDeferredReconnect() async throws {
+    func withdrawnBetterPathCancelsDeferredReconnect() throws {
         let harness = Harness()
 
         harness.connect()
@@ -94,11 +85,8 @@ struct WebSocketEngineReconnectTests {
 
         harness.respond(to: requestId)
 
-        let didReconnect = await harness.reconnectHappened(within: 0.5)
-        #expect(!didReconnect)
-
-        harness.drain()
         #expect(harness.factory.transports.count == 1)
+        #expect(!harness.engine.pendingBetterPathReconnect)
         #expect(harness.engine.state == .connected(url: Self.url))
     }
 
@@ -124,16 +112,13 @@ struct WebSocketEngineReconnectTests {
         harness.drain()
         harness.respond(to: requestId)
 
-        let reconnectedAgain = await harness.transportCountReached(3, within: 0.5)
-        #expect(!reconnectedAgain)
-
-        harness.drain()
+        #expect(harness.factory.transports.count == 2)
         #expect(harness.engine.state == .connected(url: Self.url))
     }
 
     @Test("late pong timeout after pong received does not restart the connection")
-    func latePongTimeoutAfterPongIsIgnored() async {
-        let harness = Harness(pongTimeout: 5)
+    func latePongTimeoutAfterPongIsIgnored() {
+        let harness = Harness(pongTimeout: 60)
 
         harness.connect()
 
@@ -145,23 +130,6 @@ struct WebSocketEngineReconnectTests {
         harness.drain()
 
         harness.engine.didTrigger(scheduler: harness.engine.pongTimeoutScheduler)
-        harness.drain()
-
-        #expect(harness.factory.transports.count == 1)
-        #expect(harness.engine.state == .connected(url: Self.url))
-    }
-
-    @Test("late viability timeout after recovery does not restart the connection")
-    func lateViabilityTimeoutAfterRecoveryIsIgnored() async {
-        let harness = Harness(viabilityTimeout: 5)
-
-        harness.connect()
-
-        harness.transport.simulate(.viabilityChanged(false))
-        harness.transport.simulate(.viabilityChanged(true))
-        harness.drain()
-
-        harness.engine.didTrigger(scheduler: harness.engine.viabilityTimeoutScheduler)
         harness.drain()
 
         #expect(harness.factory.transports.count == 1)
@@ -182,30 +150,9 @@ struct WebSocketEngineReconnectTests {
         #expect(harness.factory.transports.count == 2)
     }
 
-    @Test("inbound traffic keeps the connection alive without pongs")
-    func inboundTrafficSatisfiesPongTimeout() async {
-        let harness = Harness(pingInterval: 0.1, pongTimeout: 0.25)
-
-        let connection = harness.transport
-        connection.onFrame = { [weak connection] frame in
-            if frame.opcode == .ping {
-                connection?.simulateText("{\"jsonrpc\":\"2.0\",\"method\":\"noop\",\"params\":{}}")
-            }
-        }
-
-        harness.connect()
-
-        let didReconnect = await harness.reconnectHappened(within: 1)
-        #expect(!didReconnect)
-
-        harness.drain()
-        #expect(harness.factory.transports.count == 1)
-        #expect(harness.engine.state == .connected(url: Self.url))
-    }
-
     @Test("answered pings keep the connection alive")
-    func pongReceptionKeepsConnectionAlive() async {
-        let harness = Harness(pingInterval: 0.1, pongTimeout: 0.3)
+    func pongReceptionKeepsConnectionAlive() {
+        let harness = Harness(pongTimeout: 60)
 
         let connection = harness.transport
         connection.onFrame = { [weak connection] frame in
@@ -216,19 +163,48 @@ struct WebSocketEngineReconnectTests {
 
         harness.connect()
 
-        let didReconnect = await harness.reconnectHappened(within: 1)
-        #expect(!didReconnect)
+        for _ in 0 ..< 2 {
+            harness.engine.didTrigger(scheduler: harness.engine.pingScheduler)
+            harness.drain()
+        }
 
+        harness.engine.didTrigger(scheduler: harness.engine.pongTimeoutScheduler)
         harness.drain()
-        #expect(connection.pingCount >= 2)
+
+        #expect(connection.pingCount == 2)
+        #expect(harness.factory.transports.count == 1)
+        #expect(harness.engine.state == .connected(url: Self.url))
+    }
+
+    @Test("inbound traffic keeps the connection alive without pongs")
+    func inboundTrafficSatisfiesPongTimeout() {
+        let harness = Harness(pongTimeout: 60)
+
+        let connection = harness.transport
+        connection.onFrame = { [weak connection] frame in
+            if frame.opcode == .ping {
+                connection?.simulateText("{\"jsonrpc\":\"2.0\",\"method\":\"noop\",\"params\":{}}")
+            }
+        }
+
+        harness.connect()
+
+        harness.engine.didTrigger(scheduler: harness.engine.pingScheduler)
+        harness.drain()
+
+        harness.engine.didTrigger(scheduler: harness.engine.pongTimeoutScheduler)
+        harness.drain()
+
         #expect(harness.factory.transports.count == 1)
         #expect(harness.engine.state == .connected(url: Self.url))
     }
 }
 
 
-/// A reconnect always makes the engine request a fresh transport from the factory,
-/// so tests detect it by polling the number of created transports.
+/// A reconnect always makes the engine request a fresh transport from the factory.
+/// Event-driven flows are verified deterministically: `drain()` flushes the serial
+/// processing queue, and scheduler fires are injected via `didTrigger`. Only the two
+/// real-timer tests await wall-clock with a generous ceiling.
 private final class Harness {
     let engine: WebSocketEngine
     let delegate = MockWebSocketEngineDelegate()
@@ -269,7 +245,7 @@ private final class Harness {
     @discardableResult
     func submitNonResendableRequest() throws -> UInt16 {
         try engine.callMethod(
-            "extrinsic",
+            "author_submitExtrinsic",
             params: ["0x00"],
             options: JSONRPCOptions(resendOnReconnect: false)
         ) { (_: Result<String, Error>) in }
@@ -286,21 +262,17 @@ private final class Harness {
         return count
     }
 
-    func transportCountReached(_ expected: Int, within timeout: TimeInterval = 2) async -> Bool {
+    func reconnectHappened(within timeout: TimeInterval = 2) async -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
 
         while Date() < deadline {
-            if transportCount() >= expected {
+            if transportCount() >= 2 {
                 return true
             }
 
             try? await Task.sleep(nanoseconds: 50_000_000)
         }
 
-        return transportCount() >= expected
-    }
-
-    func reconnectHappened(within timeout: TimeInterval = 2) async -> Bool {
-        await transportCountReached(2, within: timeout)
+        return transportCount() >= 2
     }
 }


### PR DESCRIPTION
## CHECKLIST

**Follow the checklist to help make your PR easier to review. Check off items as you complete them.**

- [x] Did you review your own PR?

- [x] Provide a SUMMARY description for this PR below.

- [x] Provide a SOLUTION description for this PR below.

- [ ] Did you acknowledge all the feedback in this PR?


## SUMMARY
Switching between LTE and WiFi (or losing the network path) leaves the WebSocket
connection half-dead: the engine keeps waiting on a socket that will never deliver
responses, so subscriptions stall and in-flight requests hang

## SOLUTION
Detect dead connections via pong and viability timeouts and restart connection immediately.
Viability timeout: `viabilityChanged` starts a grace period `viabilityTimeout`, if viability doesn't recover, the connection restarts. Quick flaps survive untouched.

On better path suggestions defer reconnect until non-resendable inFlight requests finishes.
