### PR TITLE
Proper tx extension version support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ Carthage/Build
 Pods/
 
 _Pods.xcodeproj
+
+# Planning tool for AI
+
+.lavish/

--- a/SubstrateSdk/Classes/Extrinsic/Extrinsic.swift
+++ b/SubstrateSdk/Classes/Extrinsic/Extrinsic.swift
@@ -4,6 +4,8 @@ import BigInt
 public enum ExtrinsicConstants {
     static let extrinsicFormatVersion: UInt8 = 5
     static let legacyExtrinsicFormatVersion: UInt8 = 4
+    // legacy (v4) extrinsics and the base v5 pipeline both use transaction extension version 0
+    static let defaultExtensionVersion: UInt8 = 0
     static let signedExtrinsicType: UInt8 = 1 << 7
     static let generalExtrinsicType: UInt8 = 1 << 6
     static let bareExtrinsicType: UInt8 = 0

--- a/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift
+++ b/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift
@@ -232,6 +232,26 @@ private extension ExtrinsicBuilder {
         return try call.toScaleCompatibleJSON(with: runtimeJsonContext?.toRawContext())
     }
 
+    private func requiredExtensionIds(
+        for metadata: RuntimeMetadataProtocol
+    ) throws -> [String] {
+        switch extrinsicVersion {
+        case .V4:
+            // legacy signed extrinsics carry no extension-version byte
+            return metadata.getSignedExtensions()
+        case let .V5(extensionVersion):
+            let formatVersion = ExtrinsicConstants.extrinsicFormatVersion
+
+            // only metadata that explicitly enumerates versions (v16) is authoritative here
+            if let supportedFormatVersions = metadata.getSupportedFormatVersions(),
+               !supportedFormatVersions.contains(formatVersion) {
+                throw PostV14ExtrinsicMetadataError.unsupportedFormatVersion(formatVersion)
+            }
+
+            return try metadata.getSignedExtensions(forExtensionVersion: extensionVersion)
+        }
+    }
+
     private func prepareImplication(
         using encodingFactory: DynamicScaleEncodingFactoryProtocol,
         metadata: RuntimeMetadataProtocol
@@ -240,7 +260,7 @@ private extension ExtrinsicBuilder {
 
         let initialImplication = TransactionExtension.Implication(call: call, explicits: [], implicits: [])
 
-        let requiredExtensions = metadata.getSignedExtensions()
+        let requiredExtensions = try requiredExtensionIds(for: metadata)
 
         return try requiredExtensions.reversed().reduce(initialImplication) { implication, extensionId in
             if let transactionExtension = transactionExtensions[extensionId] {

--- a/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift
+++ b/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift
@@ -235,21 +235,26 @@ private extension ExtrinsicBuilder {
     private func requiredExtensionIds(
         for metadata: RuntimeMetadataProtocol
     ) throws -> [String] {
+        let formatVersion: UInt8
+        let extensionVersion: UInt8
+
         switch extrinsicVersion {
         case .V4:
-            // legacy signed extrinsics carry no extension-version byte
-            return metadata.getSignedExtensions()
-        case let .V5(extensionVersion):
-            let formatVersion = ExtrinsicConstants.extrinsicFormatVersion
-
-            // only metadata that explicitly enumerates versions (v16) is authoritative here
-            if let supportedFormatVersions = metadata.getSupportedFormatVersions(),
-               !supportedFormatVersions.contains(formatVersion) {
-                throw PostV14ExtrinsicMetadataError.unsupportedFormatVersion(formatVersion)
-            }
-
-            return try metadata.getSignedExtensions(forExtensionVersion: extensionVersion)
+            // legacy signed extrinsics carry no extension-version byte; they use the base version 0 pipeline
+            formatVersion = ExtrinsicConstants.legacyExtrinsicFormatVersion
+            extensionVersion = ExtrinsicConstants.defaultExtensionVersion
+        case let .V5(version):
+            formatVersion = ExtrinsicConstants.extrinsicFormatVersion
+            extensionVersion = version
         }
+
+        // only metadata that explicitly enumerates versions (v16) is authoritative here
+        if let supportedFormatVersions = metadata.getSupportedFormatVersions(),
+           !supportedFormatVersions.contains(formatVersion) {
+            throw PostV14ExtrinsicMetadataError.unsupportedFormatVersion(formatVersion)
+        }
+
+        return try metadata.getSignedExtensions(forExtensionVersion: extensionVersion)
     }
 
     private func prepareImplication(

--- a/SubstrateSdk/Classes/Runtime/Metadata/PostV14/PostV14ExtrinsicMetadataProtocol.swift
+++ b/SubstrateSdk/Classes/Runtime/Metadata/PostV14/PostV14ExtrinsicMetadataProtocol.swift
@@ -1,5 +1,32 @@
 import Foundation
 
+public enum PostV14ExtrinsicMetadataError: Error, Equatable {
+    case unsupportedFormatVersion(UInt8)
+    case unsupportedExtensionVersion(UInt8)
+    case invalidExtensionIndex(UInt32)
+}
+
 public protocol PostV14ExtrinsicMetadataProtocol {
     var signedExtensions: [SignedExtensionV14] { get }
+    // nil means the metadata doesn't enumerate supported format versions (pre-v16) — don't validate against it
+    var supportedFormatVersions: [UInt8]? { get }
+    var supportedExtensionVersions: [UInt8] { get }
+
+    func signedExtensions(forExtensionVersion version: UInt8) throws -> [SignedExtensionV14]
+}
+
+// V14/V15 have no per-version extension mapping: a single extension version 0 maps to the flat list,
+// and they don't enumerate supported format versions.
+public extension PostV14ExtrinsicMetadataProtocol {
+    var supportedFormatVersions: [UInt8]? { nil }
+
+    var supportedExtensionVersions: [UInt8] { [0] }
+
+    func signedExtensions(forExtensionVersion version: UInt8) throws -> [SignedExtensionV14] {
+        guard version == 0 else {
+            throw PostV14ExtrinsicMetadataError.unsupportedExtensionVersion(version)
+        }
+
+        return signedExtensions
+    }
 }

--- a/SubstrateSdk/Classes/Runtime/Metadata/PostV14/PostV14RuntimeMetadataProtocol.swift
+++ b/SubstrateSdk/Classes/Runtime/Metadata/PostV14/PostV14RuntimeMetadataProtocol.swift
@@ -132,6 +132,18 @@ public extension PostV14RuntimeMetadataProtocol {
         postV14Extrinsic.signedExtensions.map(\.identifier)
     }
 
+    func getSupportedFormatVersions() -> [UInt8]? {
+        postV14Extrinsic.supportedFormatVersions
+    }
+
+    func getSupportedExtensionVersions() -> [UInt8] {
+        postV14Extrinsic.supportedExtensionVersions
+    }
+
+    func getSignedExtensions(forExtensionVersion version: UInt8) throws -> [String] {
+        try postV14Extrinsic.signedExtensions(forExtensionVersion: version).map(\.identifier)
+    }
+
     func getSignedExtensionType(for identifier: String) -> String? {
         guard let signedExtension = postV14Extrinsic.signedExtensions.first(
             where: { $0.identifier == identifier }

--- a/SubstrateSdk/Classes/Runtime/Metadata/RuntimeMetadata.swift
+++ b/SubstrateSdk/Classes/Runtime/Metadata/RuntimeMetadata.swift
@@ -24,12 +24,32 @@ public protocol RuntimeMetadataProtocol {
     func getSignedExtensions() -> [String]
 
     func getSignedExtensionType(for identifier: String) -> String?
+
+    func getSupportedFormatVersions() -> [UInt8]?
+
+    func getSupportedExtensionVersions() -> [UInt8]
+
+    func getSignedExtensions(forExtensionVersion version: UInt8) throws -> [String]
 }
 
 public extension RuntimeMetadataProtocol {
     // view functions are only available starting from v16 metadata
     func getViewFunction(for _: String, functionName _: String) -> ViewFunctionQueryResult? {
         nil
+    }
+
+    // pre-v16 runtimes don't enumerate supported format versions
+    func getSupportedFormatVersions() -> [UInt8]? { nil }
+
+    // pre-v16 runtimes expose a single extension version 0 that maps to the flat list
+    func getSupportedExtensionVersions() -> [UInt8] { [0] }
+
+    func getSignedExtensions(forExtensionVersion version: UInt8) throws -> [String] {
+        guard version == 0 else {
+            throw PostV14ExtrinsicMetadataError.unsupportedExtensionVersion(version)
+        }
+
+        return getSignedExtensions()
     }
 }
 

--- a/SubstrateSdk/Classes/Runtime/Metadata/V16/ExtrinsicMetadataV16.swift
+++ b/SubstrateSdk/Classes/Runtime/Metadata/V16/ExtrinsicMetadataV16.swift
@@ -32,6 +32,34 @@ extension ExtrinsicMetadataV16: PostV14ExtrinsicMetadataProtocol {
             SignedExtensionV14(identifier: $0.identifier, type: $0.type, additionalSigned: $0.implicit)
         }
     }
+
+    public var supportedFormatVersions: [UInt8]? {
+        versions
+    }
+
+    public var supportedExtensionVersions: [UInt8] {
+        transactionExtensionsByVersion.map(\.extensionVersion)
+    }
+
+    public func signedExtensions(forExtensionVersion version: UInt8) throws -> [SignedExtensionV14] {
+        guard let entry = transactionExtensionsByVersion.first(where: { $0.extensionVersion == version }) else {
+            throw PostV14ExtrinsicMetadataError.unsupportedExtensionVersion(version)
+        }
+
+        return try entry.extensionIndexes.map { index in
+            guard Int(index) < transactionExtensions.count else {
+                throw PostV14ExtrinsicMetadataError.invalidExtensionIndex(index)
+            }
+
+            let ext = transactionExtensions[Int(index)]
+
+            return SignedExtensionV14(
+                identifier: ext.identifier,
+                type: ext.type,
+                additionalSigned: ext.implicit
+            )
+        }
+    }
 }
 
 extension ExtrinsicMetadataV16: ScaleCodable {
@@ -54,26 +82,27 @@ extension ExtrinsicMetadataV16: ScaleCodable {
     }
 }
 
-/// An entry of the BTreeMap<u8, Vec<Compact<u32>>> mapping a supported extrinsic
-/// version to the indexes of the transaction extensions used by that version.
+/// An entry of the BTreeMap<u8, Vec<Compact<u32>>> mapping a supported *transaction
+/// extension* version (the byte a v5/general extrinsic encodes after the format byte)
+/// to the indexes of the transaction extensions used by that version.
 public struct TransactionExtensionsVersionV16 {
-    public let version: UInt8
+    public let extensionVersion: UInt8
     public let extensionIndexes: [UInt32]
 
-    public init(version: UInt8, extensionIndexes: [UInt32]) {
-        self.version = version
+    public init(extensionVersion: UInt8, extensionIndexes: [UInt32]) {
+        self.extensionVersion = extensionVersion
         self.extensionIndexes = extensionIndexes
     }
 }
 
 extension TransactionExtensionsVersionV16: ScaleCodable {
     public func encode(scaleEncoder: ScaleEncoding) throws {
-        try version.encode(scaleEncoder: scaleEncoder)
+        try extensionVersion.encode(scaleEncoder: scaleEncoder)
         try extensionIndexes.map { BigUInt($0) }.encode(scaleEncoder: scaleEncoder)
     }
 
     public init(scaleDecoder: ScaleDecoding) throws {
-        version = try UInt8(scaleDecoder: scaleDecoder)
+        extensionVersion = try UInt8(scaleDecoder: scaleDecoder)
         extensionIndexes = try [BigUInt](scaleDecoder: scaleDecoder).map { index in
             guard let value = UInt32(exactly: index) else {
                 throw ScaleCodingError.unexpectedDecodedValue

--- a/Tests/Runtime/ExtrinsicMetadataV16VersioningTests.swift
+++ b/Tests/Runtime/ExtrinsicMetadataV16VersioningTests.swift
@@ -1,0 +1,91 @@
+import Testing
+@testable import SubstrateSdk
+
+struct ExtrinsicMetadataV16VersioningTests {
+    private func makeMetadata() -> ExtrinsicMetadataV16 {
+        let pool = [
+            TransactionExtensionMetadataV16(identifier: "CheckNonce", type: 10, implicit: 110),
+            TransactionExtensionMetadataV16(identifier: "ChargeTransactionPayment", type: 11, implicit: 111),
+            TransactionExtensionMetadataV16(identifier: "RestrictOrigin", type: 12, implicit: 112),
+            TransactionExtensionMetadataV16(identifier: "ChargePGAS", type: 13, implicit: 113)
+        ]
+
+        let byVersion = [
+            TransactionExtensionsVersionV16(extensionVersion: 0, extensionIndexes: [0, 1]),
+            TransactionExtensionsVersionV16(extensionVersion: 1, extensionIndexes: [2, 0, 3])
+        ]
+
+        return ExtrinsicMetadataV16(
+            versions: [4, 5],
+            addressType: 0,
+            callType: 0,
+            signatureType: 0,
+            transactionExtensionsByVersion: byVersion,
+            transactionExtensions: pool
+        )
+    }
+
+    @Test func exposesSupportedFormatAndExtensionVersions() {
+        let metadata = makeMetadata()
+
+        #expect(metadata.supportedFormatVersions == [4, 5])
+        #expect(metadata.supportedExtensionVersions == [0, 1])
+    }
+
+    @Test func resolvesVersionZeroInDeclaredOrder() throws {
+        let metadata = makeMetadata()
+
+        let extensions = try metadata.signedExtensions(forExtensionVersion: 0)
+
+        #expect(extensions.map(\.identifier) == ["CheckNonce", "ChargeTransactionPayment"])
+        // resolved through the pool, not the flat list
+        #expect(extensions.map(\.type) == [10, 11])
+        #expect(extensions.map(\.additionalSigned) == [110, 111])
+    }
+
+    @Test func resolvesVersionOneWithDifferentSetAndOrder() throws {
+        let metadata = makeMetadata()
+
+        let extensions = try metadata.signedExtensions(forExtensionVersion: 1)
+
+        #expect(extensions.map(\.identifier) == ["RestrictOrigin", "CheckNonce", "ChargePGAS"])
+        #expect(extensions.map(\.type) == [12, 10, 13])
+    }
+
+    @Test func throwsForUnsupportedExtensionVersion() {
+        let metadata = makeMetadata()
+
+        #expect(throws: PostV14ExtrinsicMetadataError.unsupportedExtensionVersion(2)) {
+            _ = try metadata.signedExtensions(forExtensionVersion: 2)
+        }
+    }
+
+    @Test func throwsForCorruptExtensionIndex() {
+        let metadata = ExtrinsicMetadataV16(
+            versions: [5],
+            addressType: 0,
+            callType: 0,
+            signatureType: 0,
+            transactionExtensionsByVersion: [
+                TransactionExtensionsVersionV16(extensionVersion: 0, extensionIndexes: [99])
+            ],
+            transactionExtensions: [
+                TransactionExtensionMetadataV16(identifier: "CheckNonce", type: 10, implicit: 110)
+            ]
+        )
+
+        #expect(throws: PostV14ExtrinsicMetadataError.invalidExtensionIndex(99)) {
+            _ = try metadata.signedExtensions(forExtensionVersion: 0)
+        }
+    }
+
+    // The flat signedExtensions (used by the V4 path / back-compat) still returns the whole pool.
+    @Test func flatSignedExtensionsReturnsWholePool() {
+        let metadata = makeMetadata()
+
+        #expect(
+            metadata.signedExtensions.map(\.identifier)
+                == ["CheckNonce", "ChargeTransactionPayment", "RestrictOrigin", "ChargePGAS"]
+        )
+    }
+}


### PR DESCRIPTION
## CHECKLIST

**Follow the checklist to help make your PR easier to review. Check off items as you complete them.**

- [x] Did you review your own PR?

- [x] Provide a SUMMARY description for this PR below.

- [x] Provide a SOLUTION description for this PR below.

- [ ] Did you acknowledge all the feedback in this PR?


# Purpose

V16 metadata maps each transaction-extension version to its own ordered set of extensions defined by `transactionExtensionsByVersion`. Current version of the builder ignores it and always used the flat extension pool, so the v5 extension-version byte and the encoded extensions were decoupled. They only matched for single-pipeline runtimes but runtimes which require different extensions for different versions were not supported.

# Solution

Make the v5 extension-version byte drive the extension set/order from metadata:

- `PostV14ExtrinsicMetadataProtocol` gains `signedExtensions(forExtensionVersion:)`, `supportedExtensionVersions`, and `supportedFormatVersions` (optional — only V16 enumerates versions; pre-v16 returns `nil`). V14/V15 default to a single transaction extension version 0 → flat list.
- `ExtrinsicMetadataV16` resolves `extensionIndexes` → extension pool (bounds-checked);
-  renamed the ambiguous `TransactionExtensionsVersionV16.version` → `extensionVersion`.
- `RuntimeMetadataProtocol` facade exposes the version-aware methods (as requirements, for correct dynamic dispatch).
- `ExtrinsicBuilder` resolves extensions by the chosen version for V5 (throws on unsupported version / format), keeps the flat list for V4. Version stays caller-chosen. Builder only validates that version is supported but never auto-pickes.
- Explicit errors via `PostV14ExtrinsicMetadataError` is introduced and replaced silent fallback
