### PR TITLE
Bump logger-ios to 0.0.2 and Operation-iOS to 2.6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/novasamatech/Crypto-iOS", exact: "0.5.0"),
-        .package(url: "https://github.com/novasamatech/Operation-iOS", exact: "2.5.0"),
+        .package(url: "https://github.com/novasamatech/Operation-iOS", exact: "2.6.0"),
         .package(url: "https://github.com/ashleymills/Reachability.swift", exact: "5.2.4"),
         .package(url: "https://github.com/novasamatech/Starscream.git", exact: "4.0.13"),
         .package(url: "https://github.com/bitmark-inc/tweetnacl-swiftwrap", exact: "1.1.0"),
@@ -35,7 +35,7 @@ let package = Package(
         .package(url: "https://github.com/novasamatech/swift-scrypt", exact: "1.0.3"),
         .package(url: "https://github.com/novasamatech/metadata-shortener-ios", exact: "0.2.1"),
         .package(url: "https://github.com/novasamatech/Foundation-iOS", exact: "1.5.0"),
-        .package(url: "https://github.com/novasamatech/logger-ios", exact: "0.0.1")
+        .package(url: "https://github.com/novasamatech/logger-ios", exact: "0.0.2")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## What

Dependency bump only — no feature changes.

- `logger-ios`: `exact "0.0.1"` → `exact "0.0.2"` (lazy `@autoclosure` log messages)
- `Operation-iOS`: `exact "2.5.0"` → `exact "2.6.0"` (2.5.0 + same logger bump, no source changes)

Part of the release train propagating logger-ios 0.0.2 up to the polkadot iOS app. Goes on top of the already-merged genesisHash change on `base/5.0` so a single 5.x release carries genesisHash + logger 0.0.2 + Operation-iOS 2.6.0.

## Source compatibility

The SDK only *holds and calls* `SDKLoggerProtocol` (e.g. `let logger: SDKLoggerProtocol?` + `logger?.debug(...)`); it does not conform to it, so the 0.0.2 signature change is source-compatible — no code edits needed.

## Verification

- `swift package resolve` → resolves `logger-ios 0.0.2`, `operation-ios 2.6.0` (confirmed in Package.resolved; not tracked — gitignored).
- `xcodebuild build -scheme SubstrateSdk -destination 'platform=iOS Simulator,id=<iPhone Air, iOS 26.5>'` → **BUILD SUCCEEDED**.
- Test action: the SPM auto-generated `SubstrateSdk` scheme is not configured for the `test` action in this environment (`Scheme SubstrateSdk is not currently configured for the test action`) — a pre-existing scheme quirk unrelated to this change. Build is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)